### PR TITLE
feat: implement count-only ingest response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # log-friends-console
 
-Spring Boot control plane and ingest server for Log Friends. It receives SDK event batches over HTTP, stores raw events in TimescaleDB tables, and manages agents, log specs, alert rules, incidents, and event statistics.
+Spring Boot control plane and ingest server for Log Friends. It receives SDK event batches over HTTP, stores raw events in TimescaleDB tables, and manages agents, log specs, raw event queries, and event statistics.
 
 ## Current Architecture
 
@@ -19,17 +19,17 @@ Kafka and Protobuf transport are excluded from the current ingest path.
 - **Raw event storage**: store events in type-specific TimescaleDB hypertables
 - **Partial failure handling**: store malformed events separately without failing the whole batch
 - **Derived stats**: generate dashboard/stat data with an internal scheduler
-- **Metadata APIs**: manage agents, log specs, alert rules, incidents, and event stats
+- **Metadata APIs**: manage agents, log specs, raw event queries, and event stats
 
 ## Raw Event Tables
 
 | Event type | Table |
 |------------|-------|
-| `LOG` | `log_events` |
+| `LOG` | `logs` |
 | `HTTP` | `http_events` |
 | `JDBC` | `jdbc_events` |
-| `METHOD_TRACE` | `method_trace_events` |
-| `LOG_EVENT` | `custom_events` |
+| `METHOD_TRACE` | `method_traces` |
+| `LOG_EVENT` | `custom_events` (`payload` JSONB) |
 
 Invalid ingest events are stored in `ingest_failed_events`. Failure statistics are stored separately in `ingest_failure_stats`.
 
@@ -65,8 +65,6 @@ The first implementation keeps stats generation inside `log-friends-console`:
 | Agents | `/api/agents` |
 | Log specs | `/api/log-specs` |
 | Event stats | `/api/event-stats` |
-| Alert rules | `/api/alert-rules` |
-| Incidents | `/api/incidents` |
 
 ## Run
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,20 @@ plugins {
     id("io.spring.dependency-management") version "1.1.6"
 }
 
+fun loadDotenv(): Map<String, String> {
+    val envFile = rootProject.file(".env")
+    if (!envFile.exists()) return emptyMap()
+
+    return envFile.readLines()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && !it.startsWith("#") && "=" in it }
+        .associate { line ->
+            val key = line.substringBefore("=").trim()
+            val value = line.substringAfter("=").trim().trim('"', '\'')
+            key to value
+        }
+}
+
 kotlin {
     jvmToolchain(21)
 }
@@ -42,6 +56,14 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
+    loadDotenv().forEach { (key, value) ->
+        if (System.getenv(key).isNullOrBlank()) {
+            environment(key, value)
+        }
+    }
 }
 
 springBoot {

--- a/src/main/kotlin/com/logfriends/platform/PlatformApplication.kt
+++ b/src/main/kotlin/com/logfriends/platform/PlatformApplication.kt
@@ -1,0 +1,13 @@
+package com.logfriends.platform
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@SpringBootApplication
+@EnableJpaAuditing
+class PlatformApplication
+
+fun main(args: Array<String>) {
+    runApplication<PlatformApplication>(*args)
+}

--- a/src/main/kotlin/com/logfriends/platform/api/dto/AgentDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/AgentDto.kt
@@ -1,0 +1,63 @@
+package com.logfriends.platform.api.dto
+
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.entity.AgentStatus
+import jakarta.validation.constraints.NotBlank
+import java.time.Instant
+
+// === Request ===
+data class AgentRegisterRequest(
+    @field:NotBlank(message = "workerId는 필수입니다")
+    val workerId: String,
+    @field:NotBlank(message = "appName은 필수입니다")
+    val appName: String,
+    val sdkVersion: String? = null,
+    val javaVersion: String? = null,
+    val hostname: String? = null,
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+data class AgentUpdateRequest(
+    val appName: String? = null,
+    val sdkVersion: String? = null,
+    val javaVersion: String? = null,
+    val hostname: String? = null,
+    val metadata: Map<String, Any>? = null
+)
+
+data class HeartbeatRequest(
+    @field:NotBlank(message = "workerId는 필수입니다")
+    val workerId: String,
+    val metadata: Map<String, Any>? = null
+)
+
+// === Response ===
+data class AgentResponse(
+    val id: Long,
+    val workerId: String,
+    val appName: String,
+    val status: AgentStatus,
+    val sdkVersion: String?,
+    val javaVersion: String?,
+    val hostname: String?,
+    val metadata: Map<String, Any>,
+    val lastHeartbeat: Instant?,
+    val registeredAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(agent: Agent) = AgentResponse(
+            id = agent.id!!,
+            workerId = agent.workerId,
+            appName = agent.appName,
+            status = agent.status,
+            sdkVersion = agent.sdkVersion,
+            javaVersion = agent.javaVersion,
+            hostname = agent.hostname,
+            metadata = agent.metadata,
+            lastHeartbeat = agent.lastHeartbeat,
+            registeredAt = agent.registeredAt,
+            updatedAt = agent.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/dto/EventStatDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/EventStatDto.kt
@@ -1,0 +1,63 @@
+package com.logfriends.platform.api.dto
+
+import com.logfriends.platform.domain.eventstat.entity.EventStat
+import com.logfriends.platform.domain.eventstat.entity.EventType
+import com.logfriends.platform.domain.eventstat.service.EventStatRequest
+import com.logfriends.platform.domain.eventstat.service.EventTypeSummary
+import java.time.Instant
+
+// === Request ===
+
+data class EventStatRecordRequest(
+    val stats: List<EventStatItemRequest>
+)
+
+data class EventStatItemRequest(
+    val eventType: EventType,
+    val windowStart: Instant,
+    val count: Long,
+    val errorCount: Long = 0,
+    val avgDurationMs: Double? = null
+) {
+    fun toServiceRequest() = EventStatRequest(eventType, windowStart, count, errorCount, avgDurationMs)
+}
+
+// === Response ===
+
+data class EventStatResponse(
+    val id: Long,
+    val agentId: Long,
+    val eventType: EventType,
+    val windowStart: Instant,
+    val count: Long,
+    val errorCount: Long,
+    val avgDurationMs: Double?
+) {
+    companion object {
+        fun from(s: EventStat) = EventStatResponse(
+            id = s.id!!,
+            agentId = s.agentId,
+            eventType = s.eventType,
+            windowStart = s.windowStart,
+            count = s.count,
+            errorCount = s.errorCount,
+            avgDurationMs = s.avgDurationMs
+        )
+    }
+}
+
+data class EventTypeSummaryResponse(
+    val eventType: EventType,
+    val totalCount: Long,
+    val totalErrorCount: Long,
+    val errorRate: Double
+) {
+    companion object {
+        fun from(s: EventTypeSummary) = EventTypeSummaryResponse(
+            eventType = s.eventType,
+            totalCount = s.totalCount,
+            totalErrorCount = s.totalErrorCount,
+            errorRate = if (s.totalCount > 0) s.totalErrorCount.toDouble() / s.totalCount else 0.0
+        )
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/dto/IngestDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/IngestDto.kt
@@ -1,0 +1,41 @@
+package com.logfriends.platform.api.dto
+
+data class IngestRequest(
+    val workerId: String,
+    val events: List<EventPayload>
+)
+
+data class IngestResponse(
+    val received: Int,
+    val stored: Int,
+    val failed: Int
+)
+
+data class EventPayload(
+    val type: String,
+    val timestamp: String,
+    // HTTP
+    val method: String? = null,
+    val uri: String? = null,
+    val statusCode: Int? = null,
+    val durationMs: Long? = null,
+    val traceId: String? = null,
+    val exceptionStack: String? = null,
+    val requestHeaders: Map<String, String>? = null,
+    // LOG
+    val level: String? = null,
+    val loggerName: String? = null,
+    val threadName: String? = null,
+    val message: String? = null,
+    val exception: String? = null,
+    val mdc: Map<String, String>? = null,
+    // JDBC
+    val sql: String? = null,
+    val rowCount: Int? = null,
+    // METHOD_TRACE
+    val className: String? = null,
+    val methodName: String? = null,
+    // LOG_EVENT
+    val eventName: String? = null,
+    val payload: Map<String, Any>? = null,
+)

--- a/src/main/kotlin/com/logfriends/platform/api/dto/LogSpecDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/LogSpecDto.kt
@@ -1,0 +1,49 @@
+package com.logfriends.platform.api.dto
+
+import com.logfriends.platform.domain.logspec.entity.LogSpecSnapshot
+import com.logfriends.platform.domain.logspec.service.LogSpecRequest
+import java.time.Instant
+
+// === Request ===
+
+data class LogSpecUpsertRequest(
+    val specs: List<LogSpecItemRequest>
+)
+
+data class LogSpecItemRequest(
+    val name: String,
+    val description: String = "",
+    val levels: List<String> = emptyList(),
+    val category: String = "BUSINESS",
+    val fields: List<Map<String, Any>> = emptyList()
+) {
+    fun toServiceRequest() = LogSpecRequest(name, description, levels, category, fields)
+}
+
+// === Response ===
+
+data class LogSpecResponse(
+    val id: Long,
+    val agentId: Long,
+    val specName: String,
+    val description: String,
+    val levels: List<String>,
+    val category: String,
+    val fields: List<Map<String, Any>>,
+    val lastSeenAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(s: LogSpecSnapshot) = LogSpecResponse(
+            id = s.id!!,
+            agentId = s.agentId,
+            specName = s.specName,
+            description = s.description,
+            levels = s.levels,
+            category = s.category,
+            fields = s.fields,
+            lastSeenAt = s.lastSeenAt,
+            updatedAt = s.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/rest/AgentController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/AgentController.kt
@@ -1,0 +1,70 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.api.dto.*
+import com.logfriends.platform.domain.agent.service.AgentService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/agents")
+class AgentController(
+    private val agentService: AgentService
+) {
+
+    @GetMapping
+    fun listAgents(): ResponseEntity<List<AgentResponse>> {
+        val agents = agentService.findAll().map { AgentResponse.from(it) }
+        return ResponseEntity.ok(agents)
+    }
+
+    @GetMapping("/{id}")
+    fun getAgent(@PathVariable id: Long): ResponseEntity<AgentResponse> {
+        val agent = agentService.findById(id)
+        return ResponseEntity.ok(AgentResponse.from(agent))
+    }
+
+    @PostMapping
+    fun registerAgent(@Valid @RequestBody request: AgentRegisterRequest): ResponseEntity<AgentResponse> {
+        val agent = agentService.register(
+            workerId = request.workerId,
+            appName = request.appName,
+            metadata = request.metadata
+        )
+        agent.updateInfo(
+            sdkVersion = request.sdkVersion,
+            javaVersion = request.javaVersion,
+            hostname = request.hostname
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(AgentResponse.from(agent))
+    }
+
+    @PatchMapping("/{id}")
+    fun updateAgent(
+        @PathVariable id: Long,
+        @RequestBody request: AgentUpdateRequest
+    ): ResponseEntity<AgentResponse> {
+        val agent = agentService.updateAgent(
+            id = id,
+            appName = request.appName,
+            sdkVersion = request.sdkVersion,
+            javaVersion = request.javaVersion,
+            hostname = request.hostname,
+            metadata = request.metadata
+        )
+        return ResponseEntity.ok(AgentResponse.from(agent))
+    }
+
+    @PostMapping("/heartbeat")
+    fun heartbeat(@Valid @RequestBody request: HeartbeatRequest): ResponseEntity<AgentResponse> {
+        val agent = agentService.heartbeat(request.workerId, request.metadata)
+        return ResponseEntity.ok(AgentResponse.from(agent))
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteAgent(@PathVariable id: Long): ResponseEntity<Void> {
+        agentService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/rest/EventQueryController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/EventQueryController.kt
@@ -1,0 +1,63 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.infrastructure.query.EventQueryService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.time.Instant
+
+@RestController
+@RequestMapping("/api/events")
+class EventQueryController(
+    private val eventQueryService: EventQueryService
+) {
+
+    @GetMapping("/http")
+    fun queryHttp(
+        @RequestParam(required = false) workerId: String?,
+        @RequestParam from: Instant,
+        @RequestParam to: Instant,
+        @RequestParam(defaultValue = "100") limit: Int
+    ): ResponseEntity<List<Map<String, Any?>>> =
+        ResponseEntity.ok(eventQueryService.queryHttpEvents(workerId, from, to, limit))
+
+    @GetMapping("/log")
+    fun queryLog(
+        @RequestParam(required = false) workerId: String?,
+        @RequestParam(required = false) level: String?,
+        @RequestParam from: Instant,
+        @RequestParam to: Instant,
+        @RequestParam(defaultValue = "100") limit: Int
+    ): ResponseEntity<List<Map<String, Any?>>> =
+        ResponseEntity.ok(eventQueryService.queryLogEvents(workerId, level, from, to, limit))
+
+    @GetMapping("/jdbc")
+    fun queryJdbc(
+        @RequestParam(required = false) workerId: String?,
+        @RequestParam from: Instant,
+        @RequestParam to: Instant,
+        @RequestParam(required = false) minDurationMs: Long?,
+        @RequestParam(defaultValue = "100") limit: Int
+    ): ResponseEntity<List<Map<String, Any?>>> =
+        ResponseEntity.ok(eventQueryService.queryJdbcEvents(workerId, from, to, minDurationMs, limit))
+
+    @GetMapping("/custom")
+    fun queryCustom(
+        @RequestParam(required = false) workerId: String?,
+        @RequestParam(required = false) eventName: String?,
+        @RequestParam from: Instant,
+        @RequestParam to: Instant,
+        @RequestParam(defaultValue = "100") limit: Int
+    ): ResponseEntity<List<Map<String, Any?>>> =
+        ResponseEntity.ok(eventQueryService.queryCustomEvents(workerId, eventName, from, to, limit))
+
+    @GetMapping("/method-trace")
+    fun queryMethodTrace(
+        @RequestParam(required = false) workerId: String?,
+        @RequestParam(required = false) className: String?,
+        @RequestParam from: Instant,
+        @RequestParam to: Instant,
+        @RequestParam(required = false) minDurationMs: Long?,
+        @RequestParam(defaultValue = "100") limit: Int
+    ): ResponseEntity<List<Map<String, Any?>>> =
+        ResponseEntity.ok(eventQueryService.queryMethodTraceEvents(workerId, className, from, to, minDurationMs, limit))
+}

--- a/src/main/kotlin/com/logfriends/platform/api/rest/EventStatController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/EventStatController.kt
@@ -1,0 +1,50 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.api.dto.*
+import com.logfriends.platform.domain.eventstat.service.EventStatService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.time.Instant
+
+@RestController
+@RequestMapping("/api/event-stats")
+class EventStatController(
+    private val eventStatService: EventStatService
+) {
+
+    /** Agent별 이벤트 통계 목록 (시간 범위 필터 가능) */
+    @GetMapping("/by-agent/{agentId}")
+    fun listByAgent(
+        @PathVariable agentId: Long,
+        @RequestParam(required = false) from: Instant?,
+        @RequestParam(required = false) to: Instant?
+    ): ResponseEntity<List<EventStatResponse>> {
+        val stats = eventStatService.findByAgent(agentId, from, to).map { EventStatResponse.from(it) }
+        return ResponseEntity.ok(stats)
+    }
+
+    /** Agent별 이벤트 타입 요약 (빅데이터 엔지니어용 카탈로그) */
+    @GetMapping("/summary/by-agent/{agentId}")
+    fun summaryByAgent(@PathVariable agentId: Long): ResponseEntity<List<EventTypeSummaryResponse>> {
+        val summary = eventStatService.summarizeByAgent(agentId).map { EventTypeSummaryResponse.from(it) }
+        return ResponseEntity.ok(summary)
+    }
+
+    /** appName별 이벤트 타입 요약 */
+    @GetMapping("/summary/by-app")
+    fun summaryByApp(@RequestParam appName: String): ResponseEntity<List<EventTypeSummaryResponse>> {
+        val summary = eventStatService.summarizeByApp(appName).map { EventTypeSummaryResponse.from(it) }
+        return ResponseEntity.ok(summary)
+    }
+
+    /** Agent가 이벤트 통계를 전송 (Spark 또는 SDK heartbeat에서 호출) */
+    @PostMapping("/by-agent/{agentId}")
+    fun record(
+        @PathVariable agentId: Long,
+        @RequestBody request: EventStatRecordRequest
+    ): ResponseEntity<Void> {
+        eventStatService.record(agentId, request.stats.map { it.toServiceRequest() })
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/rest/IngestController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/IngestController.kt
@@ -1,0 +1,20 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.api.dto.IngestRequest
+import com.logfriends.platform.api.dto.IngestResponse
+import com.logfriends.platform.ingest.IngestService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/ingest")
+class IngestController(private val ingestService: IngestService) {
+
+    @PostMapping
+    fun ingest(@RequestBody request: IngestRequest): ResponseEntity<IngestResponse> {
+        return ResponseEntity.ok(ingestService.save(request))
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/rest/LogSpecController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/LogSpecController.kt
@@ -1,0 +1,45 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.api.dto.LogSpecResponse
+import com.logfriends.platform.api.dto.LogSpecUpsertRequest
+import com.logfriends.platform.domain.logspec.service.LogSpecService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/log-specs")
+class LogSpecController(
+    private val logSpecService: LogSpecService
+) {
+
+    /** 전체 LogSpec 목록 (빅데이터 엔지니어가 전체 카탈로그 조회) */
+    @GetMapping
+    fun listAll(): ResponseEntity<List<LogSpecResponse>> {
+        val specs = logSpecService.findAll().map { LogSpecResponse.from(it) }
+        return ResponseEntity.ok(specs)
+    }
+
+    /** appName 기준으로 해당 앱의 LogSpec 조회 */
+    @GetMapping("/by-app")
+    fun listByApp(@RequestParam appName: String): ResponseEntity<List<LogSpecResponse>> {
+        val specs = logSpecService.findAllByAppName(appName).map { LogSpecResponse.from(it) }
+        return ResponseEntity.ok(specs)
+    }
+
+    /** 특정 Agent의 LogSpec 조회 */
+    @GetMapping("/by-agent/{agentId}")
+    fun listByAgent(@PathVariable agentId: Long): ResponseEntity<List<LogSpecResponse>> {
+        val specs = logSpecService.findAllByAgent(agentId).map { LogSpecResponse.from(it) }
+        return ResponseEntity.ok(specs)
+    }
+
+    /** Agent가 자신의 LogSpec을 등록/갱신 (heartbeat 시 호출) */
+    @PutMapping("/by-agent/{agentId}")
+    fun upsertSpecs(
+        @PathVariable agentId: Long,
+        @RequestBody request: LogSpecUpsertRequest
+    ): ResponseEntity<Void> {
+        logSpecService.upsertSpecs(agentId, request.specs.map { it.toServiceRequest() })
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/logfriends/platform/common/entity/BaseEntity.kt
@@ -1,0 +1,36 @@
+package com.logfriends.platform.common.entity
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+        protected set
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now()
+        protected set
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var updatedAt: Instant = Instant.now()
+        protected set
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as BaseEntity
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = this::class.hashCode()
+}

--- a/src/main/kotlin/com/logfriends/platform/common/exception/BusinessException.kt
+++ b/src/main/kotlin/com/logfriends/platform/common/exception/BusinessException.kt
@@ -1,0 +1,29 @@
+package com.logfriends.platform.common.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(
+    val status: HttpStatus,
+    val message: String
+) {
+    // 공통
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다"),
+    CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류"),
+
+    // Agent
+    AGENT_NOT_FOUND(HttpStatus.NOT_FOUND, "에이전트를 찾을 수 없습니다"),
+    AGENT_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 등록된 에이전트입니다"),
+
+    // LogSpec
+    LOG_SPEC_NOT_FOUND(HttpStatus.NOT_FOUND, "LogSpec을 찾을 수 없습니다"),
+
+    // EventStat
+    EVENT_STAT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트 통계를 찾을 수 없습니다"),
+}
+
+class BusinessException(
+    val errorCode: ErrorCode,
+    override val message: String = errorCode.message
+) : RuntimeException(message)

--- a/src/main/kotlin/com/logfriends/platform/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/logfriends/platform/common/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,45 @@
+package com.logfriends.platform.common.exception
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.time.Instant
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    data class ErrorResponse(
+        val code: String,
+        val message: String,
+        val timestamp: Instant = Instant.now()
+    )
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> {
+        log.warn("Business exception: {} - {}", e.errorCode, e.message)
+        return ResponseEntity
+            .status(e.errorCode.status)
+            .body(ErrorResponse(e.errorCode.name, e.message))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val message = e.bindingResult.fieldErrors
+            .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+        return ResponseEntity
+            .badRequest()
+            .body(ErrorResponse("VALIDATION_ERROR", message))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        log.error("Unexpected error", e)
+        return ResponseEntity
+            .internalServerError()
+            .body(ErrorResponse("INTERNAL_ERROR", "내부 서버 오류가 발생했습니다"))
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/config/AppConfig.kt
+++ b/src/main/kotlin/com/logfriends/platform/config/AppConfig.kt
@@ -1,0 +1,10 @@
+package com.logfriends.platform.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+@EnableAsync
+class AppConfig

--- a/src/main/kotlin/com/logfriends/platform/domain/agent/entity/Agent.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/agent/entity/Agent.kt
@@ -1,0 +1,66 @@
+package com.logfriends.platform.domain.agent.entity
+
+import com.logfriends.platform.common.entity.BaseEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+
+@Entity
+@Table(name = "agents")
+class Agent(
+
+    @Column(nullable = false, unique = true)
+    val workerId: String,
+
+    @Column(nullable = false)
+    var appName: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: AgentStatus = AgentStatus.UNKNOWN,
+
+    var sdkVersion: String? = null,
+
+    var javaVersion: String? = null,
+
+    var hostname: String? = null,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    var metadata: Map<String, Any> = emptyMap(),
+
+    var lastHeartbeat: Instant? = null,
+
+    @Column(nullable = false, updatable = false)
+    val registeredAt: Instant = Instant.now()
+
+) : BaseEntity() {
+
+    fun heartbeat() {
+        this.lastHeartbeat = Instant.now()
+        this.status = AgentStatus.RUNNING
+    }
+
+    fun markStopped() {
+        this.status = AgentStatus.STOPPED
+    }
+
+    fun updateInfo(
+        appName: String? = null,
+        sdkVersion: String? = null,
+        javaVersion: String? = null,
+        hostname: String? = null,
+        metadata: Map<String, Any>? = null
+    ) {
+        appName?.let { this.appName = it }
+        sdkVersion?.let { this.sdkVersion = it }
+        javaVersion?.let { this.javaVersion = it }
+        hostname?.let { this.hostname = it }
+        metadata?.let { this.metadata = it }
+    }
+}
+
+enum class AgentStatus {
+    RUNNING, STOPPED, UNKNOWN
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/agent/repository/AgentRepository.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/agent/repository/AgentRepository.kt
@@ -1,0 +1,22 @@
+package com.logfriends.platform.domain.agent.repository
+
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.entity.AgentStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
+import java.util.*
+
+interface AgentRepository : JpaRepository<Agent, Long> {
+
+    fun findByWorkerId(workerId: String): Optional<Agent>
+
+    fun existsByWorkerId(workerId: String): Boolean
+
+    fun findByStatus(status: AgentStatus): List<Agent>
+
+    @Query("SELECT a FROM Agent a WHERE a.lastHeartbeat < :threshold AND a.status = 'RUNNING'")
+    fun findStaleAgents(threshold: Instant): List<Agent>
+
+    fun findByAppNameContainingIgnoreCase(appName: String): List<Agent>
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/agent/service/AgentService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/agent/service/AgentService.kt
@@ -1,0 +1,94 @@
+package com.logfriends.platform.domain.agent.service
+
+import com.logfriends.platform.common.exception.BusinessException
+import com.logfriends.platform.common.exception.ErrorCode
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.entity.AgentStatus
+import com.logfriends.platform.domain.agent.repository.AgentRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+@Transactional(readOnly = true)
+class AgentService(
+    private val agentRepository: AgentRepository
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun findAll(): List<Agent> = agentRepository.findAll()
+
+    fun findById(id: Long): Agent =
+        agentRepository.findById(id)
+            .orElseThrow { BusinessException(ErrorCode.AGENT_NOT_FOUND) }
+
+    fun findByWorkerId(workerId: String): Agent =
+        agentRepository.findByWorkerId(workerId)
+            .orElseThrow { BusinessException(ErrorCode.AGENT_NOT_FOUND) }
+
+    @Transactional
+    fun register(workerId: String, appName: String, metadata: Map<String, Any> = emptyMap()): Agent {
+        if (agentRepository.existsByWorkerId(workerId)) {
+            throw BusinessException(ErrorCode.AGENT_ALREADY_REGISTERED)
+        }
+
+        val agent = Agent(
+            workerId = workerId,
+            appName = appName,
+            metadata = metadata,
+            status = AgentStatus.RUNNING,
+            lastHeartbeat = Instant.now()
+        )
+        return agentRepository.save(agent)
+    }
+
+    @Transactional
+    fun heartbeat(workerId: String, metadata: Map<String, Any>? = null): Agent {
+        val agent = agentRepository.findByWorkerId(workerId)
+            .orElseGet {
+                // 등록 안 된 에이전트가 heartbeat 보내면 자동 등록
+                Agent(workerId = workerId, appName = "unknown")
+            }
+
+        agent.heartbeat()
+        metadata?.let { agent.updateInfo(metadata = it) }
+        return agentRepository.save(agent)
+    }
+
+    @Transactional
+    fun updateAgent(id: Long, appName: String?, sdkVersion: String?,
+                    javaVersion: String?, hostname: String?,
+                    metadata: Map<String, Any>?): Agent {
+        val agent = findById(id)
+        agent.updateInfo(appName, sdkVersion, javaVersion, hostname, metadata)
+        return agentRepository.save(agent)
+    }
+
+    @Transactional
+    fun delete(id: Long) {
+        val agent = findById(id)
+        agentRepository.delete(agent)
+    }
+
+    /**
+     * 5분 이상 heartbeat 없는 에이전트를 STOPPED로 변경
+     * 매 1분마다 실행
+     */
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    fun checkStaleAgents() {
+        val threshold = Instant.now().minusSeconds(300) // 5분
+        val staleAgents = agentRepository.findStaleAgents(threshold)
+
+        staleAgents.forEach { agent ->
+            log.info("[Platform] Agent {} marked as STOPPED (no heartbeat since {})",
+                agent.workerId, agent.lastHeartbeat)
+            agent.markStopped()
+        }
+        if (staleAgents.isNotEmpty()) {
+            agentRepository.saveAll(staleAgents)
+        }
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/eventstat/entity/EventStat.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/eventstat/entity/EventStat.kt
@@ -1,0 +1,45 @@
+package com.logfriends.platform.domain.eventstat.entity
+
+import com.logfriends.platform.common.entity.BaseEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * Agent별 이벤트 타입 통계
+ * Spark 파이프라인이나 SDK heartbeat에서 집계해서 전송
+ * 1분 윈도우 단위로 저장
+ */
+@Entity
+@Table(
+    name = "event_stats",
+    indexes = [
+        Index(name = "idx_event_stats_agent_window", columnList = "agent_id, window_start"),
+        Index(name = "idx_event_stats_event_type", columnList = "event_type")
+    ]
+)
+class EventStat(
+
+    @Column(name = "agent_id", nullable = false)
+    val agentId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false)
+    val eventType: EventType,
+
+    @Column(name = "window_start", nullable = false)
+    val windowStart: Instant,
+
+    @Column(nullable = false)
+    var count: Long = 0,
+
+    @Column(name = "error_count", nullable = false)
+    var errorCount: Long = 0,
+
+    /** HTTP/JDBC/METHOD_TRACE 평균 응답시간(ms), LOG/LOG_EVENT는 null */
+    var avgDurationMs: Double? = null
+
+) : BaseEntity()
+
+enum class EventType {
+    HTTP, LOG, JDBC, METHOD_TRACE, LOG_EVENT
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/eventstat/repository/EventStatRepository.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/eventstat/repository/EventStatRepository.kt
@@ -1,0 +1,41 @@
+package com.logfriends.platform.domain.eventstat.repository
+
+import com.logfriends.platform.domain.eventstat.entity.EventStat
+import com.logfriends.platform.domain.eventstat.entity.EventType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
+
+interface EventStatRepository : JpaRepository<EventStat, Long> {
+
+    fun findAllByAgentId(agentId: Long): List<EventStat>
+
+    fun findAllByAgentIdAndWindowStartBetween(
+        agentId: Long, from: Instant, to: Instant
+    ): List<EventStat>
+
+    /** Agent별 이벤트 타입 총합 (전체 기간) */
+    @Query("""
+        SELECT s.eventType, SUM(s.count), SUM(s.errorCount)
+        FROM EventStat s
+        WHERE s.agentId = :agentId
+        GROUP BY s.eventType
+    """)
+    fun sumByAgentIdGroupByType(agentId: Long): List<Array<Any>>
+
+    /** appName 기준 전체 통계 */
+    @Query("""
+        SELECT s.eventType, SUM(s.count), SUM(s.errorCount)
+        FROM EventStat s
+        WHERE s.agentId IN (
+            SELECT a.id FROM Agent a WHERE a.appName = :appName
+        )
+        GROUP BY s.eventType
+    """)
+    fun sumByAppNameGroupByType(appName: String): List<Array<Any>>
+
+    /** 최근 N분 윈도우 조회 */
+    fun findAllByAgentIdAndEventTypeAndWindowStartAfter(
+        agentId: Long, eventType: EventType, after: Instant
+    ): List<EventStat>
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/eventstat/service/EventStatService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/eventstat/service/EventStatService.kt
@@ -1,0 +1,80 @@
+package com.logfriends.platform.domain.eventstat.service
+
+import com.logfriends.platform.common.exception.BusinessException
+import com.logfriends.platform.common.exception.ErrorCode
+import com.logfriends.platform.domain.agent.repository.AgentRepository
+import com.logfriends.platform.domain.eventstat.entity.EventStat
+import com.logfriends.platform.domain.eventstat.entity.EventType
+import com.logfriends.platform.domain.eventstat.repository.EventStatRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+@Transactional(readOnly = true)
+class EventStatService(
+    private val eventStatRepository: EventStatRepository,
+    private val agentRepository: AgentRepository
+) {
+
+    fun findByAgent(agentId: Long, from: Instant?, to: Instant?): List<EventStat> {
+        if (!agentRepository.existsById(agentId)) throw BusinessException(ErrorCode.AGENT_NOT_FOUND)
+        return if (from != null && to != null) {
+            eventStatRepository.findAllByAgentIdAndWindowStartBetween(agentId, from, to)
+        } else {
+            eventStatRepository.findAllByAgentId(agentId)
+        }
+    }
+
+    /** Agent별 이벤트 타입 요약 */
+    fun summarizeByAgent(agentId: Long): List<EventTypeSummary> {
+        if (!agentRepository.existsById(agentId)) throw BusinessException(ErrorCode.AGENT_NOT_FOUND)
+        return eventStatRepository.sumByAgentIdGroupByType(agentId).map {
+            EventTypeSummary(
+                eventType = it[0] as EventType,
+                totalCount = (it[1] as Long),
+                totalErrorCount = (it[2] as Long)
+            )
+        }
+    }
+
+    /** appName별 이벤트 타입 요약 */
+    fun summarizeByApp(appName: String): List<EventTypeSummary> =
+        eventStatRepository.sumByAppNameGroupByType(appName).map {
+            EventTypeSummary(
+                eventType = it[0] as EventType,
+                totalCount = (it[1] as Long),
+                totalErrorCount = (it[2] as Long)
+            )
+        }
+
+    @Transactional
+    fun record(agentId: Long, requests: List<EventStatRequest>) {
+        if (!agentRepository.existsById(agentId)) throw BusinessException(ErrorCode.AGENT_NOT_FOUND)
+        val stats = requests.map {
+            EventStat(
+                agentId = agentId,
+                eventType = it.eventType,
+                windowStart = it.windowStart,
+                count = it.count,
+                errorCount = it.errorCount,
+                avgDurationMs = it.avgDurationMs
+            )
+        }
+        eventStatRepository.saveAll(stats)
+    }
+}
+
+data class EventTypeSummary(
+    val eventType: EventType,
+    val totalCount: Long,
+    val totalErrorCount: Long
+)
+
+data class EventStatRequest(
+    val eventType: EventType,
+    val windowStart: Instant,
+    val count: Long,
+    val errorCount: Long = 0,
+    val avgDurationMs: Double? = null
+)

--- a/src/main/kotlin/com/logfriends/platform/domain/logspec/entity/LogSpecSnapshot.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/logspec/entity/LogSpecSnapshot.kt
@@ -1,0 +1,57 @@
+package com.logfriends.platform.domain.logspec.entity
+
+import com.logfriends.platform.common.entity.BaseEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+
+/**
+ * SDK에서 등록된 LogSpec 정의를 스냅샷으로 저장
+ * Agent가 heartbeat 시 자신의 LogSpec 목록을 함께 전송
+ */
+@Entity
+@Table(
+    name = "log_spec_snapshots",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["agent_id", "spec_name"])]
+)
+class LogSpecSnapshot(
+
+    @Column(name = "agent_id", nullable = false)
+    val agentId: Long,
+
+    @Column(name = "spec_name", nullable = false)
+    val specName: String,
+
+    @Column(nullable = false)
+    var description: String = "",
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    var levels: List<String> = emptyList(),
+
+    @Column(nullable = false)
+    var category: String = "BUSINESS",
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    var fields: List<Map<String, Any>> = emptyList(),
+
+    @Column(nullable = false)
+    var lastSeenAt: Instant = Instant.now()
+
+) : BaseEntity() {
+
+    fun update(
+        description: String,
+        levels: List<String>,
+        category: String,
+        fields: List<Map<String, Any>>
+    ) {
+        this.description = description
+        this.levels = levels
+        this.category = category
+        this.fields = fields
+        this.lastSeenAt = Instant.now()
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/logspec/repository/LogSpecSnapshotRepository.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/logspec/repository/LogSpecSnapshotRepository.kt
@@ -1,0 +1,22 @@
+package com.logfriends.platform.domain.logspec.repository
+
+import com.logfriends.platform.domain.logspec.entity.LogSpecSnapshot
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface LogSpecSnapshotRepository : JpaRepository<LogSpecSnapshot, Long> {
+
+    fun findAllByAgentId(agentId: Long): List<LogSpecSnapshot>
+
+    fun findByAgentIdAndSpecName(agentId: Long, specName: String): LogSpecSnapshot?
+
+    @Query("""
+        SELECT s FROM LogSpecSnapshot s
+        WHERE s.agentId IN (
+            SELECT a.id FROM Agent a WHERE a.appName = :appName
+        )
+    """)
+    fun findAllByAppName(appName: String): List<LogSpecSnapshot>
+
+    fun deleteAllByAgentId(agentId: Long)
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/logspec/service/LogSpecService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/logspec/service/LogSpecService.kt
@@ -1,0 +1,71 @@
+package com.logfriends.platform.domain.logspec.service
+
+import com.logfriends.platform.common.exception.BusinessException
+import com.logfriends.platform.common.exception.ErrorCode
+import com.logfriends.platform.domain.agent.repository.AgentRepository
+import com.logfriends.platform.domain.logspec.entity.LogSpecSnapshot
+import com.logfriends.platform.domain.logspec.repository.LogSpecSnapshotRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class LogSpecService(
+    private val logSpecSnapshotRepository: LogSpecSnapshotRepository,
+    private val agentRepository: AgentRepository
+) {
+
+    fun findAllByAgent(agentId: Long): List<LogSpecSnapshot> {
+        if (!agentRepository.existsById(agentId)) {
+            throw BusinessException(ErrorCode.AGENT_NOT_FOUND)
+        }
+        return logSpecSnapshotRepository.findAllByAgentId(agentId)
+    }
+
+    fun findAllByAppName(appName: String): List<LogSpecSnapshot> =
+        logSpecSnapshotRepository.findAllByAppName(appName)
+
+    fun findAll(): List<LogSpecSnapshot> =
+        logSpecSnapshotRepository.findAll()
+
+    /**
+     * Agent heartbeat 시 LogSpec 목록을 upsert
+     * 같은 agentId + specName이면 업데이트, 없으면 신규 저장
+     */
+    @Transactional
+    fun upsertSpecs(agentId: Long, specs: List<LogSpecRequest>) {
+        if (!agentRepository.existsById(agentId)) {
+            throw BusinessException(ErrorCode.AGENT_NOT_FOUND)
+        }
+        specs.forEach { req ->
+            val existing = logSpecSnapshotRepository.findByAgentIdAndSpecName(agentId, req.name)
+            if (existing != null) {
+                existing.update(req.description, req.levels, req.category, req.fields)
+            } else {
+                logSpecSnapshotRepository.save(
+                    LogSpecSnapshot(
+                        agentId = agentId,
+                        specName = req.name,
+                        description = req.description,
+                        levels = req.levels,
+                        category = req.category,
+                        fields = req.fields
+                    )
+                )
+            }
+        }
+    }
+
+    @Transactional
+    fun deleteAllByAgent(agentId: Long) {
+        logSpecSnapshotRepository.deleteAllByAgentId(agentId)
+    }
+}
+
+data class LogSpecRequest(
+    val name: String,
+    val description: String = "",
+    val levels: List<String> = emptyList(),
+    val category: String = "BUSINESS",
+    val fields: List<Map<String, Any>> = emptyList()
+)

--- a/src/main/kotlin/com/logfriends/platform/infrastructure/query/EventQueryService.kt
+++ b/src/main/kotlin/com/logfriends/platform/infrastructure/query/EventQueryService.kt
@@ -1,0 +1,126 @@
+package com.logfriends.platform.infrastructure.query
+
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+/**
+ * SDK가 /ingest 로 전송한 원시 이벤트 조회
+ * PostgreSQL Raw Event 테이블 조회.
+ */
+@Service
+class EventQueryService(
+    private val dsl: DSLContext
+) {
+
+    /** HTTP 이벤트 조회 */
+    fun queryHttpEvents(
+        workerId: String?,
+        from: Instant,
+        to: Instant,
+        limit: Int = 100
+    ): List<Map<String, Any?>> {
+        val conditions = mutableListOf(
+            DSL.field("ts").between(from, to)
+        )
+        workerId?.let { conditions.add(DSL.field("worker_id").eq(it)) }
+
+        return dsl.select()
+            .from(DSL.table("http_events"))
+            .where(conditions)
+            .orderBy(DSL.field("ts").desc())
+            .limit(limit)
+            .fetchMaps()
+    }
+
+    /** LOG 이벤트 조회 */
+    fun queryLogEvents(
+        workerId: String?,
+        level: String?,
+        from: Instant,
+        to: Instant,
+        limit: Int = 100
+    ): List<Map<String, Any?>> {
+        val conditions = mutableListOf(
+            DSL.field("ts").between(from, to)
+        )
+        workerId?.let { conditions.add(DSL.field("worker_id").eq(it)) }
+        level?.let { conditions.add(DSL.field("level").eq(it)) }
+
+        return dsl.select()
+            .from(DSL.table("logs"))
+            .where(conditions)
+            .orderBy(DSL.field("ts").desc())
+            .limit(limit)
+            .fetchMaps()
+    }
+
+    /** JDBC 이벤트 조회 */
+    fun queryJdbcEvents(
+        workerId: String?,
+        from: Instant,
+        to: Instant,
+        minDurationMs: Long? = null,
+        limit: Int = 100
+    ): List<Map<String, Any?>> {
+        val conditions = mutableListOf(
+            DSL.field("ts").between(from, to)
+        )
+        workerId?.let { conditions.add(DSL.field("worker_id").eq(it)) }
+        minDurationMs?.let { conditions.add(DSL.field("duration_ms").ge(it)) }
+
+        return dsl.select()
+            .from(DSL.table("jdbc_events"))
+            .where(conditions)
+            .orderBy(DSL.field("duration_ms").desc())
+            .limit(limit)
+            .fetchMaps()
+    }
+
+    /** @LogEvent 커스텀 이벤트 조회 */
+    fun queryCustomEvents(
+        workerId: String?,
+        eventName: String?,
+        from: Instant,
+        to: Instant,
+        limit: Int = 100
+    ): List<Map<String, Any?>> {
+        val conditions = mutableListOf(
+            DSL.field("ts").between(from, to)
+        )
+        workerId?.let { conditions.add(DSL.field("worker_id").eq(it)) }
+        eventName?.let { conditions.add(DSL.field("event_name").eq(it)) }
+
+        return dsl.select()
+            .from(DSL.table("custom_events"))
+            .where(conditions)
+            .orderBy(DSL.field("ts").desc())
+            .limit(limit)
+            .fetchMaps()
+    }
+
+    /** METHOD_TRACE 이벤트 조회 */
+    fun queryMethodTraceEvents(
+        workerId: String?,
+        className: String?,
+        from: Instant,
+        to: Instant,
+        minDurationMs: Long? = null,
+        limit: Int = 100
+    ): List<Map<String, Any?>> {
+        val conditions = mutableListOf(
+            DSL.field("ts").between(from, to)
+        )
+        workerId?.let { conditions.add(DSL.field("worker_id").eq(it)) }
+        className?.let { conditions.add(DSL.field("class_name").eq(it)) }
+        minDurationMs?.let { conditions.add(DSL.field("duration_ms").ge(it)) }
+
+        return dsl.select()
+            .from(DSL.table("method_traces"))
+            .where(conditions)
+            .orderBy(DSL.field("duration_ms").desc())
+            .limit(limit)
+            .fetchMaps()
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/ingest/IngestFailureReason.kt
+++ b/src/main/kotlin/com/logfriends/platform/ingest/IngestFailureReason.kt
@@ -1,0 +1,11 @@
+package com.logfriends.platform.ingest
+
+enum class IngestFailureReason(val message: String) {
+    MISSING_WORKER_ID("workerId is blank"),
+    MISSING_TYPE("event type is blank"),
+    UNKNOWN_TYPE("event type is not supported"),
+    MISSING_TIMESTAMP("timestamp is blank"),
+    INVALID_TIMESTAMP("timestamp is not ISO-8601 instant"),
+    MISSING_EVENT_NAME("LOG_EVENT eventName is blank"),
+    STORE_FAILED("raw event store failed")
+}

--- a/src/main/kotlin/com/logfriends/platform/ingest/IngestService.kt
+++ b/src/main/kotlin/com/logfriends/platform/ingest/IngestService.kt
@@ -1,0 +1,224 @@
+package com.logfriends.platform.ingest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.logfriends.platform.api.dto.EventPayload
+import com.logfriends.platform.api.dto.IngestRequest
+import com.logfriends.platform.api.dto.IngestResponse
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class IngestService(
+    private val dsl: DSLContext,
+    private val objectMapper: ObjectMapper,
+    private val ingestValidator: IngestValidator = IngestValidator()
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun save(request: IngestRequest): IngestResponse {
+        if (request.events.isEmpty()) {
+            return IngestResponse(received = 0, stored = 0, failed = 0)
+        }
+
+        var stored = 0
+        var failed = 0
+
+        request.events.forEach { event ->
+            val validation = ingestValidator.validate(request.workerId, event)
+            if (validation != null) {
+                failed++
+                saveFailedEvent(request.workerId, event, validation)
+                return@forEach
+            }
+
+            try {
+                when (event.type) {
+                "LOG" -> {
+                    saveLogEvents(request.workerId, listOf(event))
+                    stored++
+                }
+                "HTTP" -> {
+                    saveHttpEvents(request.workerId, listOf(event))
+                    stored++
+                }
+                "JDBC" -> {
+                    saveJdbcEvents(request.workerId, listOf(event))
+                    stored++
+                }
+                "METHOD_TRACE" -> {
+                    saveMethodTraceEvents(request.workerId, listOf(event))
+                    stored++
+                }
+                "LOG_EVENT" -> {
+                    saveCustomEvents(request.workerId, listOf(event))
+                    stored++
+                }
+                else -> {
+                    failed++
+                    saveFailedEvent(request.workerId, event, IngestFailureReason.UNKNOWN_TYPE)
+                }
+            }
+            } catch (ex: Exception) {
+                failed++
+                log.error(
+                    "[Ingest] raw event store failed worker={} type={}",
+                    request.workerId,
+                    event.type,
+                    ex
+                )
+                saveFailedEvent(request.workerId, event, IngestFailureReason.STORE_FAILED)
+            }
+        }
+
+        log.debug(
+            "[Ingest] worker={} received={} stored={} failed={}",
+            request.workerId,
+            request.events.size,
+            stored,
+            failed
+        )
+
+        return IngestResponse(
+            received = request.events.size,
+            stored = stored,
+            failed = failed
+        )
+    }
+
+    private fun saveLogEvents(workerId: String, events: List<EventPayload>) {
+        dsl.batch(events.map { e ->
+            dsl.insertInto(DSL.table("logs"))
+                .columns(
+                    DSL.field("worker_id"), DSL.field("ts"),
+                    DSL.field("level"), DSL.field("logger_name"),
+                    DSL.field("thread_name"), DSL.field("message"),
+                    DSL.field("exception"), DSL.field("exception_stack"),
+                    DSL.field("trace_id"), DSL.field("mdc")
+                )
+                .values(
+                    workerId, ingestValidator.parseTsOrNull(e.timestamp)!!,
+                    e.level ?: "INFO", e.loggerName ?: "",
+                    e.threadName ?: "", e.message ?: "",
+                    e.exception ?: "", e.exceptionStack ?: "",
+                    e.traceId ?: "", toJsonb(e.mdc)
+                )
+        }).execute()
+    }
+
+    private fun saveHttpEvents(workerId: String, events: List<EventPayload>) {
+        dsl.batch(events.map { e ->
+            dsl.insertInto(DSL.table("http_events"))
+                .columns(
+                    DSL.field("worker_id"), DSL.field("ts"),
+                    DSL.field("method"), DSL.field("uri"),
+                    DSL.field("status_code"), DSL.field("duration_ms"),
+                    DSL.field("trace_id"), DSL.field("exception_stack"),
+                    DSL.field("request_headers")
+                )
+                .values(
+                    workerId, ingestValidator.parseTsOrNull(e.timestamp)!!,
+                    e.method ?: "", e.uri ?: "",
+                    e.statusCode ?: 0, e.durationMs ?: 0L,
+                    e.traceId ?: "", e.exceptionStack ?: "",
+                    toJsonb(e.requestHeaders)
+                )
+        }).execute()
+    }
+
+    private fun saveJdbcEvents(workerId: String, events: List<EventPayload>) {
+        dsl.batch(events.map { e ->
+            dsl.insertInto(DSL.table("jdbc_events"))
+                .columns(
+                    DSL.field("worker_id"), DSL.field("ts"),
+                    DSL.field("sql_text"), DSL.field("duration_ms"),
+                    DSL.field("row_count"), DSL.field("trace_id"),
+                    DSL.field("exception"), DSL.field("exception_stack")
+                )
+                .values(
+                    workerId, ingestValidator.parseTsOrNull(e.timestamp)!!,
+                    e.sql ?: "", e.durationMs ?: 0L,
+                    e.rowCount ?: 0, e.traceId ?: "",
+                    e.exception ?: "", e.exceptionStack ?: ""
+                )
+        }).execute()
+    }
+
+    private fun saveMethodTraceEvents(workerId: String, events: List<EventPayload>) {
+        dsl.batch(events.map { e ->
+            dsl.insertInto(DSL.table("method_traces"))
+                .columns(
+                    DSL.field("worker_id"), DSL.field("ts"),
+                    DSL.field("class_name"), DSL.field("method_name"),
+                    DSL.field("duration_ms"), DSL.field("trace_id"),
+                    DSL.field("exception"), DSL.field("exception_stack")
+                )
+                .values(
+                    workerId, ingestValidator.parseTsOrNull(e.timestamp)!!,
+                    e.className ?: "", e.methodName ?: "",
+                    e.durationMs ?: 0L, e.traceId ?: "",
+                    e.exception ?: "", e.exceptionStack ?: ""
+                )
+        }).execute()
+    }
+
+    private fun saveCustomEvents(workerId: String, events: List<EventPayload>) {
+        dsl.batch(events.map { e ->
+            dsl.insertInto(DSL.table("custom_events"))
+                .columns(
+                    DSL.field("worker_id"), DSL.field("ts"),
+                    DSL.field("event_name"), DSL.field("payload")
+                )
+                .values(
+                    workerId, ingestValidator.parseTsOrNull(e.timestamp)!!,
+                    e.eventName ?: "unknown", toJsonb(e.payload)
+                )
+        }).execute()
+    }
+
+    private fun saveFailedEvent(workerId: String, event: EventPayload, reason: IngestFailureReason) {
+        try {
+            dsl.insertInto(DSL.table("ingest_failed_events"))
+                .columns(
+                    DSL.field("worker_id"),
+                    DSL.field("event_type"),
+                    DSL.field("reason_code"),
+                    DSL.field("reason"),
+                    DSL.field("payload")
+                )
+                .values(
+                    workerId.ifBlank { null },
+                    event.type.ifBlank { null },
+                    reason.name,
+                    reason.message,
+                    toJsonb(toPayloadJson(event))
+                )
+                .execute()
+
+            log.warn(
+                "[Ingest] failed worker={} reason={} type={}",
+                workerId,
+                reason.name,
+                event.type
+            )
+        } catch (ex: Exception) {
+            log.error(
+                "[Ingest] failed event store failed worker={} reason={} type={}",
+                workerId,
+                reason.name,
+                event.type,
+                ex
+            )
+        }
+    }
+
+    private fun toPayloadJson(event: EventPayload): Map<String, Any?> {
+        val node = objectMapper.valueToTree<ObjectNode>(event)
+        return objectMapper.convertValue(node, Map::class.java) as Map<String, Any?>
+    }
+
+    private fun toJsonb(map: Map<*, *>?): String =
+        if (map.isNullOrEmpty()) "{}" else objectMapper.writeValueAsString(map)
+}

--- a/src/main/kotlin/com/logfriends/platform/ingest/IngestValidator.kt
+++ b/src/main/kotlin/com/logfriends/platform/ingest/IngestValidator.kt
@@ -1,0 +1,29 @@
+package com.logfriends.platform.ingest
+
+import com.logfriends.platform.api.dto.EventPayload
+import java.time.Instant
+
+class IngestValidator {
+
+    fun validate(workerId: String, event: EventPayload): IngestFailureReason? {
+        if (workerId.isBlank()) return IngestFailureReason.MISSING_WORKER_ID
+        if (event.type.isBlank()) return IngestFailureReason.MISSING_TYPE
+        if (event.type !in SUPPORTED_TYPES) return IngestFailureReason.UNKNOWN_TYPE
+        if (event.timestamp.isBlank()) return IngestFailureReason.MISSING_TIMESTAMP
+        if (parseTsOrNull(event.timestamp) == null) return IngestFailureReason.INVALID_TIMESTAMP
+        if (event.type == "LOG_EVENT" && event.eventName.isNullOrBlank()) {
+            return IngestFailureReason.MISSING_EVENT_NAME
+        }
+        return null
+    }
+
+    fun parseTsOrNull(ts: String): Instant? = try {
+        Instant.parse(ts)
+    } catch (_: Exception) {
+        null
+    }
+
+    private companion object {
+        private val SUPPORTED_TYPES = setOf("HTTP", "LOG", "JDBC", "METHOD_TRACE", "LOG_EVENT")
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,50 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: log-friends-platform
+
+  datasource:
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5433}/${POSTGRES_DB:logfriends_platform}
+    username: ${POSTGRES_USER:logfriends}
+    password: ${POSTGRES_PASSWORD:logfriends}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 30000
+
+  jpa:
+    hibernate:
+      ddl-auto: validate # Flyway가 스키마 관리 → Hibernate는 검증만
+    open-in-view: false # OSIV 비활성 → 성능 예측 가능
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100 # N+1 방지
+        jdbc:
+          batch_size: 50 # 배치 INSERT 최적화
+        order_inserts: true
+        order_updates: true
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+
+logfriends:
+  ingest:
+    queue-capacity: 10000
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.jooq: DEBUG
+    com.logfriends.platform: DEBUG

--- a/src/main/resources/db/migration/V1__create_agents.sql
+++ b/src/main/resources/db/migration/V1__create_agents.sql
@@ -1,0 +1,19 @@
+CREATE TABLE agents (
+    id              BIGSERIAL    PRIMARY KEY,
+    worker_id       VARCHAR(100) NOT NULL UNIQUE,
+    app_name        VARCHAR(100) NOT NULL,
+    status          VARCHAR(20)  NOT NULL DEFAULT 'UNKNOWN',
+    sdk_version     VARCHAR(50),
+    java_version    VARCHAR(50),
+    hostname        VARCHAR(255),
+    metadata        JSONB        NOT NULL DEFAULT '{}',
+    last_heartbeat  TIMESTAMPTZ,
+    registered_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_agents_worker_id ON agents(worker_id);
+CREATE INDEX idx_agents_app_name ON agents(app_name);
+CREATE INDEX idx_agents_status ON agents(status);
+CREATE INDEX idx_agents_metadata ON agents USING GIN (metadata);

--- a/src/main/resources/db/migration/V2__create_log_spec_snapshots.sql
+++ b/src/main/resources/db/migration/V2__create_log_spec_snapshots.sql
@@ -1,0 +1,17 @@
+CREATE TABLE log_spec_snapshots (
+    id           BIGSERIAL    PRIMARY KEY,
+    agent_id     BIGINT       NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    spec_name    VARCHAR(200) NOT NULL,
+    description  TEXT         NOT NULL DEFAULT '',
+    levels       JSONB        NOT NULL DEFAULT '[]',
+    category     VARCHAR(50)  NOT NULL DEFAULT 'BUSINESS',
+    fields       JSONB        NOT NULL DEFAULT '[]',
+    last_seen_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_log_spec_agent_name UNIQUE (agent_id, spec_name)
+);
+
+CREATE INDEX idx_log_spec_snapshots_agent_id ON log_spec_snapshots(agent_id);
+CREATE INDEX idx_log_spec_snapshots_spec_name ON log_spec_snapshots(spec_name);

--- a/src/main/resources/db/migration/V3__create_raw_event_tables.sql
+++ b/src/main/resources/db/migration/V3__create_raw_event_tables.sql
@@ -1,0 +1,76 @@
+CREATE TABLE http_events (
+    id              BIGINT       GENERATED ALWAYS AS IDENTITY,
+    worker_id       VARCHAR(100) NOT NULL,
+    ts              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    method          VARCHAR(10)  NOT NULL DEFAULT '',
+    uri             TEXT         NOT NULL DEFAULT '',
+    status_code     INT          NOT NULL DEFAULT 0,
+    duration_ms     BIGINT       NOT NULL DEFAULT 0,
+    trace_id        VARCHAR(100) NOT NULL DEFAULT '',
+    exception_stack TEXT         NOT NULL DEFAULT '',
+    request_headers JSONB        NOT NULL DEFAULT '{}',
+    PRIMARY KEY (id, ts)
+);
+
+CREATE TABLE logs (
+    id              BIGINT       GENERATED ALWAYS AS IDENTITY,
+    worker_id       VARCHAR(100) NOT NULL,
+    ts              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    level           VARCHAR(10)  NOT NULL DEFAULT 'INFO',
+    logger_name     TEXT         NOT NULL DEFAULT '',
+    thread_name     TEXT         NOT NULL DEFAULT '',
+    message         TEXT         NOT NULL DEFAULT '',
+    exception       TEXT         NOT NULL DEFAULT '',
+    exception_stack TEXT         NOT NULL DEFAULT '',
+    trace_id        VARCHAR(100) NOT NULL DEFAULT '',
+    mdc             JSONB        NOT NULL DEFAULT '{}',
+    PRIMARY KEY (id, ts)
+);
+
+CREATE TABLE jdbc_events (
+    id              BIGINT       GENERATED ALWAYS AS IDENTITY,
+    worker_id       VARCHAR(100) NOT NULL,
+    ts              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    sql_text        TEXT         NOT NULL DEFAULT '',
+    duration_ms     BIGINT       NOT NULL DEFAULT 0,
+    row_count       INT          NOT NULL DEFAULT 0,
+    trace_id        VARCHAR(100) NOT NULL DEFAULT '',
+    exception       TEXT         NOT NULL DEFAULT '',
+    exception_stack TEXT         NOT NULL DEFAULT '',
+    PRIMARY KEY (id, ts)
+);
+
+CREATE TABLE method_traces (
+    id              BIGINT       GENERATED ALWAYS AS IDENTITY,
+    worker_id       VARCHAR(100) NOT NULL,
+    ts              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    class_name      TEXT         NOT NULL DEFAULT '',
+    method_name     TEXT         NOT NULL DEFAULT '',
+    duration_ms     BIGINT       NOT NULL DEFAULT 0,
+    trace_id        VARCHAR(100) NOT NULL DEFAULT '',
+    exception       TEXT         NOT NULL DEFAULT '',
+    exception_stack TEXT         NOT NULL DEFAULT '',
+    PRIMARY KEY (id, ts)
+);
+
+CREATE TABLE custom_events (
+    id          BIGINT       GENERATED ALWAYS AS IDENTITY,
+    worker_id   VARCHAR(100) NOT NULL,
+    ts          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    event_name  TEXT         NOT NULL,
+    payload     JSONB        NOT NULL DEFAULT '{}',
+    PRIMARY KEY (id, ts)
+);
+
+CREATE INDEX idx_http_events_worker_ts ON http_events(worker_id, ts DESC);
+CREATE INDEX idx_http_events_status ON http_events(status_code);
+CREATE INDEX idx_http_events_duration ON http_events(duration_ms DESC);
+CREATE INDEX idx_logs_worker_ts ON logs(worker_id, ts DESC);
+CREATE INDEX idx_logs_level ON logs(level);
+CREATE INDEX idx_jdbc_events_worker_ts ON jdbc_events(worker_id, ts DESC);
+CREATE INDEX idx_jdbc_events_duration ON jdbc_events(duration_ms DESC);
+CREATE INDEX idx_method_traces_worker_ts ON method_traces(worker_id, ts DESC);
+CREATE INDEX idx_method_traces_duration ON method_traces(duration_ms DESC);
+CREATE INDEX idx_custom_events_worker_ts ON custom_events(worker_id, ts DESC);
+CREATE INDEX idx_custom_events_event_name ON custom_events(event_name);
+CREATE INDEX idx_custom_events_payload ON custom_events USING GIN (payload);

--- a/src/main/resources/db/migration/V4__create_event_stats.sql
+++ b/src/main/resources/db/migration/V4__create_event_stats.sql
@@ -1,0 +1,17 @@
+CREATE TABLE event_stats (
+    id              BIGSERIAL    PRIMARY KEY,
+    agent_id        BIGINT       NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    event_type      VARCHAR(20)  NOT NULL,
+    window_start    TIMESTAMPTZ  NOT NULL,
+    count           BIGINT       NOT NULL DEFAULT 0,
+    error_count     BIGINT       NOT NULL DEFAULT 0,
+    avg_duration_ms DOUBLE PRECISION,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_event_stats_agent_type_window UNIQUE (agent_id, event_type, window_start)
+);
+
+CREATE INDEX idx_event_stats_agent_window ON event_stats(agent_id, window_start DESC);
+CREATE INDEX idx_event_stats_event_type ON event_stats(event_type);
+CREATE INDEX idx_event_stats_window_start ON event_stats(window_start DESC);

--- a/src/main/resources/db/migration/V5__create_ingest_failures.sql
+++ b/src/main/resources/db/migration/V5__create_ingest_failures.sql
@@ -1,0 +1,28 @@
+CREATE TABLE ingest_failed_events (
+    id           BIGINT       GENERATED ALWAYS AS IDENTITY,
+    worker_id    VARCHAR(100),
+    event_type   VARCHAR(50),
+    reason_code  VARCHAR(50)  NOT NULL,
+    reason       TEXT         NOT NULL DEFAULT '',
+    received_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    failed_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    payload      JSONB        NOT NULL DEFAULT '{}',
+    PRIMARY KEY (id, failed_at)
+);
+
+CREATE TABLE ingest_failure_stats (
+    id           BIGSERIAL    PRIMARY KEY,
+    worker_id    VARCHAR(100) NOT NULL,
+    reason_code  VARCHAR(50)  NOT NULL,
+    window_start TIMESTAMPTZ  NOT NULL,
+    count        BIGINT       NOT NULL DEFAULT 0,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_ingest_failure_stats_worker_reason_window UNIQUE (worker_id, reason_code, window_start)
+);
+
+CREATE INDEX idx_ingest_failed_events_worker_failed_at ON ingest_failed_events(worker_id, failed_at DESC);
+CREATE INDEX idx_ingest_failed_events_reason_code ON ingest_failed_events(reason_code);
+CREATE INDEX idx_ingest_failure_stats_worker_window ON ingest_failure_stats(worker_id, window_start DESC);
+CREATE INDEX idx_ingest_failure_stats_reason_code ON ingest_failure_stats(reason_code);

--- a/src/main/resources/db/migration/V6__create_timescaledb_hypertables.sql
+++ b/src/main/resources/db/migration/V6__create_timescaledb_hypertables.sql
@@ -1,0 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+SELECT create_hypertable('http_events',          'ts',        if_not_exists => TRUE);
+SELECT create_hypertable('logs',                 'ts',        if_not_exists => TRUE);
+SELECT create_hypertable('jdbc_events',          'ts',        if_not_exists => TRUE);
+SELECT create_hypertable('method_traces',        'ts',        if_not_exists => TRUE);
+SELECT create_hypertable('custom_events',        'ts',        if_not_exists => TRUE);
+SELECT create_hypertable('ingest_failed_events', 'failed_at', if_not_exists => TRUE);

--- a/src/test/kotlin/com/logfriends/platform/ingest/IngestValidatorTest.kt
+++ b/src/test/kotlin/com/logfriends/platform/ingest/IngestValidatorTest.kt
@@ -1,0 +1,90 @@
+package com.logfriends.platform.ingest
+
+import com.logfriends.platform.api.dto.EventPayload
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class IngestValidatorTest {
+    private val validator = IngestValidator()
+
+    @Test
+    fun `returns null for valid HTTP event`() {
+        val event = event(type = "HTTP")
+
+        val result = validator.validate(workerId = "worker-1", event = event)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns MISSING_WORKER_ID when workerId is blank`() {
+        val result = validator.validate(workerId = " ", event = event(type = "HTTP"))
+
+        assertThat(result).isEqualTo(IngestFailureReason.MISSING_WORKER_ID)
+    }
+
+    @Test
+    fun `returns MISSING_TYPE when type is blank`() {
+        val result = validator.validate(workerId = "worker-1", event = event(type = " "))
+
+        assertThat(result).isEqualTo(IngestFailureReason.MISSING_TYPE)
+    }
+
+    @Test
+    fun `returns UNKNOWN_TYPE when type is unsupported`() {
+        val result = validator.validate(workerId = "worker-1", event = event(type = "UNKNOWN"))
+
+        assertThat(result).isEqualTo(IngestFailureReason.UNKNOWN_TYPE)
+    }
+
+    @Test
+    fun `returns MISSING_TIMESTAMP when timestamp is blank`() {
+        val result = validator.validate(
+            workerId = "worker-1",
+            event = event(type = "HTTP", timestamp = " ")
+        )
+
+        assertThat(result).isEqualTo(IngestFailureReason.MISSING_TIMESTAMP)
+    }
+
+    @Test
+    fun `returns INVALID_TIMESTAMP when timestamp is not ISO instant`() {
+        val result = validator.validate(
+            workerId = "worker-1",
+            event = event(type = "HTTP", timestamp = "2026-05-13 12:00:00")
+        )
+
+        assertThat(result).isEqualTo(IngestFailureReason.INVALID_TIMESTAMP)
+    }
+
+    @Test
+    fun `returns MISSING_EVENT_NAME when LOG_EVENT eventName is blank`() {
+        val result = validator.validate(
+            workerId = "worker-1",
+            event = event(type = "LOG_EVENT", eventName = " ")
+        )
+
+        assertThat(result).isEqualTo(IngestFailureReason.MISSING_EVENT_NAME)
+    }
+
+    @Test
+    fun `returns null when LOG_EVENT has eventName`() {
+        val result = validator.validate(
+            workerId = "worker-1",
+            event = event(type = "LOG_EVENT", eventName = "order.created")
+        )
+
+        assertThat(result).isNull()
+    }
+
+    private fun event(
+        type: String,
+        timestamp: String = "2026-05-13T00:00:00Z",
+        eventName: String? = null
+    ): EventPayload =
+        EventPayload(
+            type = type,
+            timestamp = timestamp,
+            eventName = eventName
+        )
+}


### PR DESCRIPTION
## Summary
- Implement `POST /ingest` count response with `received`, `stored`, and `failed`
- Store valid events into type-specific raw event tables and invalid events into `ingest_failed_events`
- Add `IngestValidator`, fixed failure reasons, and validator unit tests
- Keep the current single Console + TimescaleDB path without broker/worker split

## Verification
- `./gradlew test`
- `./gradlew build`
- Manual `/ingest` request returned `{ "received": 4, "stored": 2, "failed": 2 }`

## Notes
- Local `.env`, `Dockerfile`, and `bin/` changes were intentionally not included.

Closes #1