### PR TITLE
fix: heartbeat Agent 자동 등록 제거

### DIFF
--- a/src/main/kotlin/com/logfriends/platform/api/rest/AgentController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/AgentController.kt
@@ -30,12 +30,10 @@ class AgentController(
         val agent = agentService.register(
             workerId = request.workerId,
             appName = request.appName,
-            metadata = request.metadata
-        )
-        agent.updateInfo(
             sdkVersion = request.sdkVersion,
             javaVersion = request.javaVersion,
-            hostname = request.hostname
+            hostname = request.hostname,
+            metadata = request.metadata
         )
         return ResponseEntity.status(HttpStatus.CREATED).body(AgentResponse.from(agent))
     }

--- a/src/main/kotlin/com/logfriends/platform/domain/agent/service/AgentService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/agent/service/AgentService.kt
@@ -29,7 +29,14 @@ class AgentService(
             .orElseThrow { BusinessException(ErrorCode.AGENT_NOT_FOUND) }
 
     @Transactional
-    fun register(workerId: String, appName: String, metadata: Map<String, Any> = emptyMap()): Agent {
+    fun register(
+        workerId: String,
+        appName: String,
+        sdkVersion: String? = null,
+        javaVersion: String? = null,
+        hostname: String? = null,
+        metadata: Map<String, Any> = emptyMap()
+    ): Agent {
         if (agentRepository.existsByWorkerId(workerId)) {
             throw BusinessException(ErrorCode.AGENT_ALREADY_REGISTERED)
         }
@@ -41,16 +48,18 @@ class AgentService(
             status = AgentStatus.RUNNING,
             lastHeartbeat = Instant.now()
         )
+        agent.updateInfo(
+            sdkVersion = sdkVersion,
+            javaVersion = javaVersion,
+            hostname = hostname
+        )
         return agentRepository.save(agent)
     }
 
     @Transactional
     fun heartbeat(workerId: String, metadata: Map<String, Any>? = null): Agent {
         val agent = agentRepository.findByWorkerId(workerId)
-            .orElseGet {
-                // 등록 안 된 에이전트가 heartbeat 보내면 자동 등록
-                Agent(workerId = workerId, appName = "unknown")
-            }
+            .orElseThrow { BusinessException(ErrorCode.AGENT_NOT_FOUND) }
 
         agent.heartbeat()
         metadata?.let { agent.updateInfo(metadata = it) }

--- a/src/test/kotlin/com/logfriends/platform/domain/agent/service/AgentServiceTest.kt
+++ b/src/test/kotlin/com/logfriends/platform/domain/agent/service/AgentServiceTest.kt
@@ -1,0 +1,84 @@
+package com.logfriends.platform.domain.agent.service
+
+import com.logfriends.platform.common.exception.BusinessException
+import com.logfriends.platform.common.exception.ErrorCode
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.entity.AgentStatus
+import com.logfriends.platform.domain.agent.repository.AgentRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class AgentServiceTest {
+
+    private val agentRepository: AgentRepository = mock()
+    private val agentService = AgentService(agentRepository)
+
+    @Test
+    fun `register stores app name and runtime metadata`() {
+        given(agentRepository.existsByWorkerId("demo-worker-1")).willReturn(false)
+        given(agentRepository.save(ArgumentMatchers.any(Agent::class.java))).willAnswer { it.arguments[0] }
+
+        val result = agentService.register(
+            workerId = "demo-worker-1",
+            appName = "demo-app",
+            sdkVersion = "local-test",
+            javaVersion = "21",
+            hostname = "local",
+            metadata = mapOf("env" to "test")
+        )
+
+        assertThat(result.workerId).isEqualTo("demo-worker-1")
+        assertThat(result.appName).isEqualTo("demo-app")
+        assertThat(result.sdkVersion).isEqualTo("local-test")
+        assertThat(result.javaVersion).isEqualTo("21")
+        assertThat(result.hostname).isEqualTo("local")
+        assertThat(result.metadata).containsEntry("env", "test")
+        assertThat(result.status).isEqualTo(AgentStatus.RUNNING)
+        assertThat(result.lastHeartbeat).isNotNull()
+    }
+
+    @Test
+    fun `known worker heartbeat updates existing agent`() {
+        val agent = Agent(
+            workerId = "demo-worker-1",
+            appName = "demo-app",
+            status = AgentStatus.UNKNOWN
+        )
+        given(agentRepository.findByWorkerId("demo-worker-1")).willReturn(Optional.of(agent))
+        given(agentRepository.save(agent)).willReturn(agent)
+
+        val result = agentService.heartbeat(
+            workerId = "demo-worker-1",
+            metadata = mapOf("hostname" to "local")
+        )
+
+        assertThat(result.status).isEqualTo(AgentStatus.RUNNING)
+        assertThat(result.lastHeartbeat).isNotNull()
+        assertThat(result.metadata).containsEntry("hostname", "local")
+        verify(agentRepository).save(agent)
+    }
+
+    @Test
+    fun `unknown worker heartbeat does not create agent`() {
+        given(agentRepository.findByWorkerId("unknown-worker")).willReturn(Optional.empty())
+
+        assertThatThrownBy {
+            agentService.heartbeat("unknown-worker")
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.AGENT_NOT_FOUND)
+
+        verify(agentRepository, never()).save(ArgumentMatchers.any(Agent::class.java))
+    }
+}


### PR DESCRIPTION
## Summary
- unknown worker heartbeat가 Agent를 자동 생성하지 않고 `AGENT_NOT_FOUND`를 반환하도록 변경했습니다.
- Agent 등록 시 `appName`과 SDK/runtime metadata가 서비스 레이어에서 함께 저장되도록 정리했습니다.
- AgentService 단위 테스트로 등록, known heartbeat, unknown heartbeat 경계를 고정했습니다.

## Verification
- `./gradlew test`
- `./gradlew build`
- `./gradlew bootRun --args='--server.port=18082'`
- unknown heartbeat: 404 `AGENT_NOT_FOUND`
- register Agent: 201
- known heartbeat: 200

Closes #4