### PR TITLE
fix: align raw event query ordering

### DIFF
--- a/src/main/kotlin/com/logfriends/platform/api/rest/EventQueryController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/EventQueryController.kt
@@ -15,40 +15,36 @@ class EventQueryController(
     fun queryHttp(
         @RequestParam(required = false) workerId: String?,
         @RequestParam from: Instant,
-        @RequestParam to: Instant,
-        @RequestParam(defaultValue = "100") limit: Int
+        @RequestParam to: Instant
     ): ResponseEntity<List<Map<String, Any?>>> =
-        ResponseEntity.ok(eventQueryService.queryHttpEvents(workerId, from, to, limit))
+        ResponseEntity.ok(eventQueryService.queryHttpEvents(workerId, from, to))
 
     @GetMapping("/log")
     fun queryLog(
         @RequestParam(required = false) workerId: String?,
         @RequestParam(required = false) level: String?,
         @RequestParam from: Instant,
-        @RequestParam to: Instant,
-        @RequestParam(defaultValue = "100") limit: Int
+        @RequestParam to: Instant
     ): ResponseEntity<List<Map<String, Any?>>> =
-        ResponseEntity.ok(eventQueryService.queryLogEvents(workerId, level, from, to, limit))
+        ResponseEntity.ok(eventQueryService.queryLogEvents(workerId, level, from, to))
 
     @GetMapping("/jdbc")
     fun queryJdbc(
         @RequestParam(required = false) workerId: String?,
         @RequestParam from: Instant,
         @RequestParam to: Instant,
-        @RequestParam(required = false) minDurationMs: Long?,
-        @RequestParam(defaultValue = "100") limit: Int
+        @RequestParam(required = false) minDurationMs: Long?
     ): ResponseEntity<List<Map<String, Any?>>> =
-        ResponseEntity.ok(eventQueryService.queryJdbcEvents(workerId, from, to, minDurationMs, limit))
+        ResponseEntity.ok(eventQueryService.queryJdbcEvents(workerId, from, to, minDurationMs))
 
     @GetMapping("/custom")
     fun queryCustom(
         @RequestParam(required = false) workerId: String?,
         @RequestParam(required = false) eventName: String?,
         @RequestParam from: Instant,
-        @RequestParam to: Instant,
-        @RequestParam(defaultValue = "100") limit: Int
+        @RequestParam to: Instant
     ): ResponseEntity<List<Map<String, Any?>>> =
-        ResponseEntity.ok(eventQueryService.queryCustomEvents(workerId, eventName, from, to, limit))
+        ResponseEntity.ok(eventQueryService.queryCustomEvents(workerId, eventName, from, to))
 
     @GetMapping("/method-trace")
     fun queryMethodTrace(
@@ -56,8 +52,7 @@ class EventQueryController(
         @RequestParam(required = false) className: String?,
         @RequestParam from: Instant,
         @RequestParam to: Instant,
-        @RequestParam(required = false) minDurationMs: Long?,
-        @RequestParam(defaultValue = "100") limit: Int
+        @RequestParam(required = false) minDurationMs: Long?
     ): ResponseEntity<List<Map<String, Any?>>> =
-        ResponseEntity.ok(eventQueryService.queryMethodTraceEvents(workerId, className, from, to, minDurationMs, limit))
+        ResponseEntity.ok(eventQueryService.queryMethodTraceEvents(workerId, className, from, to, minDurationMs))
 }

--- a/src/main/kotlin/com/logfriends/platform/infrastructure/query/EventQueryService.kt
+++ b/src/main/kotlin/com/logfriends/platform/infrastructure/query/EventQueryService.kt
@@ -18,8 +18,7 @@ class EventQueryService(
     fun queryHttpEvents(
         workerId: String?,
         from: Instant,
-        to: Instant,
-        limit: Int = 100
+        to: Instant
     ): List<Map<String, Any?>> {
         val conditions = mutableListOf(
             DSL.field("ts").between(from, to)
@@ -29,8 +28,7 @@ class EventQueryService(
         return dsl.select()
             .from(DSL.table("http_events"))
             .where(conditions)
-            .orderBy(DSL.field("ts").desc())
-            .limit(limit)
+            .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
             .fetchMaps()
     }
 
@@ -39,8 +37,7 @@ class EventQueryService(
         workerId: String?,
         level: String?,
         from: Instant,
-        to: Instant,
-        limit: Int = 100
+        to: Instant
     ): List<Map<String, Any?>> {
         val conditions = mutableListOf(
             DSL.field("ts").between(from, to)
@@ -51,8 +48,7 @@ class EventQueryService(
         return dsl.select()
             .from(DSL.table("logs"))
             .where(conditions)
-            .orderBy(DSL.field("ts").desc())
-            .limit(limit)
+            .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
             .fetchMaps()
     }
 
@@ -61,8 +57,7 @@ class EventQueryService(
         workerId: String?,
         from: Instant,
         to: Instant,
-        minDurationMs: Long? = null,
-        limit: Int = 100
+        minDurationMs: Long? = null
     ): List<Map<String, Any?>> {
         val conditions = mutableListOf(
             DSL.field("ts").between(from, to)
@@ -73,8 +68,7 @@ class EventQueryService(
         return dsl.select()
             .from(DSL.table("jdbc_events"))
             .where(conditions)
-            .orderBy(DSL.field("duration_ms").desc())
-            .limit(limit)
+            .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
             .fetchMaps()
     }
 
@@ -83,8 +77,7 @@ class EventQueryService(
         workerId: String?,
         eventName: String?,
         from: Instant,
-        to: Instant,
-        limit: Int = 100
+        to: Instant
     ): List<Map<String, Any?>> {
         val conditions = mutableListOf(
             DSL.field("ts").between(from, to)
@@ -95,8 +88,7 @@ class EventQueryService(
         return dsl.select()
             .from(DSL.table("custom_events"))
             .where(conditions)
-            .orderBy(DSL.field("ts").desc())
-            .limit(limit)
+            .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
             .fetchMaps()
     }
 
@@ -106,8 +98,7 @@ class EventQueryService(
         className: String?,
         from: Instant,
         to: Instant,
-        minDurationMs: Long? = null,
-        limit: Int = 100
+        minDurationMs: Long? = null
     ): List<Map<String, Any?>> {
         val conditions = mutableListOf(
             DSL.field("ts").between(from, to)
@@ -119,8 +110,7 @@ class EventQueryService(
         return dsl.select()
             .from(DSL.table("method_traces"))
             .where(conditions)
-            .orderBy(DSL.field("duration_ms").desc())
-            .limit(limit)
+            .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
             .fetchMaps()
     }
 }


### PR DESCRIPTION
## Summary
- remove limit parameters from raw event query endpoints for the first-phase API contract
- order all raw event queries by ts ASC, id ASC
- keep existing filters for workerId, level, eventName, className, and minDurationMs

## Why
Issue #5 is about making GET /api/events/* match the current Flyway raw event table schema and keeping the first query contract simple. DESC ordering and pagination are deferred until the dashboard flow needs them.

## Validation
- ./gradlew test
- ./gradlew build

Closes #5