### PR TITLE
docs: align local console port

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd log-friends-console
 Console runs on:
 
 ```text
-http://localhost:8082
+http://localhost:8080
 ```
 
 ## Configuration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8082
+  port: 8080
 
 spring:
   application:


### PR DESCRIPTION
## Summary
- set the default Console port to 8080
- update README local Console URL to 8080

## Validation
- ./gradlew build