### PR TITLE
feat: extend agent registration handshake response

### DIFF
--- a/src/main/kotlin/com/logfriends/platform/api/dto/AgentDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/AgentDto.kt
@@ -2,6 +2,7 @@ package com.logfriends.platform.api.dto
 
 import com.logfriends.platform.domain.agent.entity.Agent
 import com.logfriends.platform.domain.agent.entity.AgentStatus
+import com.logfriends.platform.domain.logspec.entity.LogSpecSnapshot
 import jakarta.validation.constraints.NotBlank
 import java.time.Instant
 
@@ -58,6 +59,53 @@ data class AgentResponse(
             lastHeartbeat = agent.lastHeartbeat,
             registeredAt = agent.registeredAt,
             updatedAt = agent.updatedAt
+        )
+    }
+}
+
+data class AgentRegistrationResponse(
+    val agentId: Long,
+    val workerId: String,
+    val appName: String,
+    val status: AgentStatus,
+    val sdkVersion: String?,
+    val javaVersion: String?,
+    val hostname: String?,
+    val metadata: Map<String, Any>,
+    val lastHeartbeat: Instant?,
+    val registeredAt: Instant,
+    val updatedAt: Instant,
+    val knownLogSpecs: List<KnownLogSpecResponse>
+) {
+    companion object {
+        fun from(agent: Agent, knownLogSpecs: List<LogSpecSnapshot>) = AgentRegistrationResponse(
+            agentId = agent.id!!,
+            workerId = agent.workerId,
+            appName = agent.appName,
+            status = agent.status,
+            sdkVersion = agent.sdkVersion,
+            javaVersion = agent.javaVersion,
+            hostname = agent.hostname,
+            metadata = agent.metadata,
+            lastHeartbeat = agent.lastHeartbeat,
+            registeredAt = agent.registeredAt,
+            updatedAt = agent.updatedAt,
+            knownLogSpecs = knownLogSpecs
+                .distinctBy { it.specName }
+                .sortedBy { it.specName }
+                .map { KnownLogSpecResponse.from(it) }
+        )
+    }
+}
+
+data class KnownLogSpecResponse(
+    val eventName: String,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(spec: LogSpecSnapshot) = KnownLogSpecResponse(
+            eventName = spec.specName,
+            updatedAt = spec.updatedAt
         )
     }
 }

--- a/src/main/kotlin/com/logfriends/platform/api/dto/DiscoveredLogEventDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/DiscoveredLogEventDto.kt
@@ -1,0 +1,61 @@
+package com.logfriends.platform.api.dto
+
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEvent
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEventStatus
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import java.time.Instant
+
+data class DiscoveredLogEventReportRequest(
+    @field:NotBlank(message = "workerId는 필수입니다")
+    val workerId: String,
+    @field:NotBlank(message = "appName은 필수입니다")
+    val appName: String,
+    val appVersion: String? = null,
+    @field:Valid
+    val events: List<DiscoveredLogEventItemRequest> = emptyList()
+)
+
+data class DiscoveredLogEventItemRequest(
+    val eventName: String,
+    val sourceClass: String,
+    val sourceMethod: String,
+    val parameterNames: List<String> = emptyList()
+)
+
+data class DiscoveredLogEventReportResponse(
+    val received: Int,
+    val upserted: Int
+)
+
+data class DiscoveredLogEventResponse(
+    val id: Long,
+    val agentId: Long,
+    val eventName: String,
+    val sourceClass: String,
+    val sourceMethod: String,
+    val parameterNames: List<String>,
+    val appVersion: String?,
+    val status: DiscoveredLogEventStatus,
+    val firstSeenAt: Instant,
+    val lastSeenAt: Instant,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(discoveredLogEvent: DiscoveredLogEvent) = DiscoveredLogEventResponse(
+            id = discoveredLogEvent.id!!,
+            agentId = discoveredLogEvent.agent.id!!,
+            eventName = discoveredLogEvent.eventName,
+            sourceClass = discoveredLogEvent.sourceClass,
+            sourceMethod = discoveredLogEvent.sourceMethod,
+            parameterNames = discoveredLogEvent.parameterNames,
+            appVersion = discoveredLogEvent.appVersion,
+            status = discoveredLogEvent.status,
+            firstSeenAt = discoveredLogEvent.firstSeenAt,
+            lastSeenAt = discoveredLogEvent.lastSeenAt,
+            createdAt = discoveredLogEvent.createdAt,
+            updatedAt = discoveredLogEvent.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/api/rest/AgentController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/AgentController.kt
@@ -2,6 +2,7 @@ package com.logfriends.platform.api.rest
 
 import com.logfriends.platform.api.dto.*
 import com.logfriends.platform.domain.agent.service.AgentService
+import com.logfriends.platform.domain.logspec.service.LogSpecService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -10,7 +11,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/agents")
 class AgentController(
-    private val agentService: AgentService
+    private val agentService: AgentService,
+    private val logSpecService: LogSpecService
 ) {
 
     @GetMapping
@@ -26,7 +28,7 @@ class AgentController(
     }
 
     @PostMapping
-    fun registerAgent(@Valid @RequestBody request: AgentRegisterRequest): ResponseEntity<AgentResponse> {
+    fun registerAgent(@Valid @RequestBody request: AgentRegisterRequest): ResponseEntity<AgentRegistrationResponse> {
         val agent = agentService.register(
             workerId = request.workerId,
             appName = request.appName,
@@ -35,7 +37,10 @@ class AgentController(
             hostname = request.hostname,
             metadata = request.metadata
         )
-        return ResponseEntity.status(HttpStatus.CREATED).body(AgentResponse.from(agent))
+        val knownLogSpecs = logSpecService.findAllByAppName(agent.appName)
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(AgentRegistrationResponse.from(agent, knownLogSpecs))
     }
 
     @PatchMapping("/{id}")

--- a/src/main/kotlin/com/logfriends/platform/api/rest/DiscoveredLogEventController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/DiscoveredLogEventController.kt
@@ -1,0 +1,35 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.api.dto.DiscoveredLogEventReportRequest
+import com.logfriends.platform.api.dto.DiscoveredLogEventReportResponse
+import com.logfriends.platform.api.dto.DiscoveredLogEventResponse
+import com.logfriends.platform.domain.discoveredlogevent.service.DiscoveredLogEventService
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/agents/{agentId}/discovered-log-events")
+class DiscoveredLogEventController(
+    private val discoveredLogEventService: DiscoveredLogEventService
+) {
+
+    @PostMapping
+    fun report(
+        @PathVariable agentId: Long,
+        @Valid @RequestBody request: DiscoveredLogEventReportRequest
+    ): ResponseEntity<DiscoveredLogEventReportResponse> =
+        ResponseEntity.ok(discoveredLogEventService.report(agentId, request))
+
+    @GetMapping
+    fun findAll(@PathVariable agentId: Long): ResponseEntity<List<DiscoveredLogEventResponse>> =
+        ResponseEntity.ok(
+            discoveredLogEventService.findAll(agentId)
+                .map { DiscoveredLogEventResponse.from(it) }
+        )
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/entity/DiscoveredLogEvent.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/entity/DiscoveredLogEvent.kt
@@ -1,0 +1,75 @@
+package com.logfriends.platform.domain.discoveredlogevent.entity
+
+import com.logfriends.platform.common.entity.BaseEntity
+import com.logfriends.platform.domain.agent.entity.Agent
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "discovered_log_events",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_discovered_log_events_source",
+            columnNames = ["agent_id", "event_name", "source_class", "source_method"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_discovered_log_events_agent_status", columnList = "agent_id, status"),
+        Index(name = "idx_discovered_log_events_event_name", columnList = "event_name")
+    ]
+)
+class DiscoveredLogEvent(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_id", nullable = false)
+    val agent: Agent,
+
+    @Column(name = "event_name", nullable = false)
+    val eventName: String,
+
+    @Column(name = "source_class", nullable = false)
+    val sourceClass: String,
+
+    @Column(name = "source_method", nullable = false)
+    val sourceMethod: String,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "parameter_names", columnDefinition = "jsonb", nullable = false)
+    var parameterNames: List<String> = emptyList(),
+
+    @Column(name = "app_version")
+    var appVersion: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: DiscoveredLogEventStatus = DiscoveredLogEventStatus.DISCOVERED,
+
+    @Column(name = "first_seen_at", nullable = false, updatable = false)
+    val firstSeenAt: Instant = Instant.now(),
+
+    @Column(name = "last_seen_at", nullable = false)
+    var lastSeenAt: Instant = Instant.now()
+) : BaseEntity() {
+
+    fun refresh(
+        parameterNames: List<String>,
+        appVersion: String?,
+        observedAt: Instant = Instant.now()
+    ) {
+        this.parameterNames = parameterNames
+        this.appVersion = appVersion
+        this.lastSeenAt = observedAt
+    }
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/entity/DiscoveredLogEventStatus.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/entity/DiscoveredLogEventStatus.kt
@@ -1,0 +1,6 @@
+package com.logfriends.platform.domain.discoveredlogevent.entity
+
+enum class DiscoveredLogEventStatus {
+    DISCOVERED,
+    IGNORED
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/repository/DiscoveredLogEventRepository.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/repository/DiscoveredLogEventRepository.kt
@@ -1,0 +1,17 @@
+package com.logfriends.platform.domain.discoveredlogevent.repository
+
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEvent
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface DiscoveredLogEventRepository : JpaRepository<DiscoveredLogEvent, Long> {
+
+    fun findByAgentIdAndEventNameAndSourceClassAndSourceMethod(
+        agentId: Long,
+        eventName: String,
+        sourceClass: String,
+        sourceMethod: String
+    ): Optional<DiscoveredLogEvent>
+
+    fun findAllByAgentIdOrderByEventNameAscSourceClassAscSourceMethodAsc(agentId: Long): List<DiscoveredLogEvent>
+}

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventService.kt
@@ -1,0 +1,119 @@
+package com.logfriends.platform.domain.discoveredlogevent.service
+
+import com.logfriends.platform.api.dto.DiscoveredLogEventItemRequest
+import com.logfriends.platform.api.dto.DiscoveredLogEventReportRequest
+import com.logfriends.platform.api.dto.DiscoveredLogEventReportResponse
+import com.logfriends.platform.common.exception.BusinessException
+import com.logfriends.platform.common.exception.ErrorCode
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.repository.AgentRepository
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEvent
+import com.logfriends.platform.domain.discoveredlogevent.repository.DiscoveredLogEventRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+@Transactional(readOnly = true)
+class DiscoveredLogEventService(
+    private val agentRepository: AgentRepository,
+    private val discoveredLogEventRepository: DiscoveredLogEventRepository
+) {
+
+    @Transactional
+    fun report(agentId: Long, request: DiscoveredLogEventReportRequest): DiscoveredLogEventReportResponse {
+        val agent = findAgent(agentId)
+        validateAgentMatch(agent, request)
+        validateBatchSize(request.events)
+
+        val observedAt = Instant.now()
+        request.events.forEach { event ->
+            validateEvent(event)
+            upsert(agent, event, request.appVersion, observedAt)
+        }
+
+        return DiscoveredLogEventReportResponse(
+            received = request.events.size,
+            upserted = request.events.size
+        )
+    }
+
+    fun findAll(agentId: Long): List<DiscoveredLogEvent> {
+        findAgent(agentId)
+        return discoveredLogEventRepository.findAllByAgentIdOrderByEventNameAscSourceClassAscSourceMethodAsc(agentId)
+    }
+
+    private fun upsert(
+        agent: Agent,
+        event: DiscoveredLogEventItemRequest,
+        appVersion: String?,
+        observedAt: Instant
+    ) {
+        val existing = discoveredLogEventRepository.findByAgentIdAndEventNameAndSourceClassAndSourceMethod(
+            agentId = agent.id!!,
+            eventName = event.eventName,
+            sourceClass = event.sourceClass,
+            sourceMethod = event.sourceMethod
+        )
+
+        val discoveredLogEvent = existing
+            .map {
+                it.refresh(
+                    parameterNames = event.parameterNames,
+                    appVersion = appVersion,
+                    observedAt = observedAt
+                )
+                it
+            }
+            .orElseGet {
+                DiscoveredLogEvent(
+                    agent = agent,
+                    eventName = event.eventName,
+                    sourceClass = event.sourceClass,
+                    sourceMethod = event.sourceMethod,
+                    parameterNames = event.parameterNames,
+                    appVersion = appVersion,
+                    firstSeenAt = observedAt,
+                    lastSeenAt = observedAt
+                )
+            }
+
+        discoveredLogEventRepository.save(discoveredLogEvent)
+    }
+
+    private fun findAgent(agentId: Long): Agent =
+        agentRepository.findById(agentId)
+            .orElseThrow { BusinessException(ErrorCode.AGENT_NOT_FOUND) }
+
+    private fun validateAgentMatch(agent: Agent, request: DiscoveredLogEventReportRequest) {
+        if (agent.workerId != request.workerId || agent.appName != request.appName) {
+            throw BusinessException(ErrorCode.CONFLICT, "agent identity does not match workerId/appName")
+        }
+    }
+
+    private fun validateBatchSize(events: List<DiscoveredLogEventItemRequest>) {
+        if (events.size > MAX_EVENTS_PER_REPORT) {
+            throw BusinessException(ErrorCode.INVALID_REQUEST, "events must be less than or equal to $MAX_EVENTS_PER_REPORT")
+        }
+    }
+
+    private fun validateEvent(event: DiscoveredLogEventItemRequest) {
+        if (event.eventName.isBlank()) {
+            throw BusinessException(ErrorCode.INVALID_REQUEST, "eventName is required")
+        }
+        if (!EVENT_NAME_PATTERN.matches(event.eventName)) {
+            throw BusinessException(ErrorCode.INVALID_REQUEST, "eventName must be camelCase")
+        }
+        if (event.sourceClass.isBlank()) {
+            throw BusinessException(ErrorCode.INVALID_REQUEST, "sourceClass is required")
+        }
+        if (event.sourceMethod.isBlank()) {
+            throw BusinessException(ErrorCode.INVALID_REQUEST, "sourceMethod is required")
+        }
+    }
+
+    companion object {
+        private const val MAX_EVENTS_PER_REPORT = 500
+        private val EVENT_NAME_PATTERN = Regex("^[a-z][a-zA-Z0-9]*$")
+    }
+}

--- a/src/main/resources/db/migration/V10__create_discovered_log_events.sql
+++ b/src/main/resources/db/migration/V10__create_discovered_log_events.sql
@@ -1,0 +1,23 @@
+CREATE TABLE discovered_log_events (
+    id              BIGSERIAL    PRIMARY KEY,
+    agent_id        BIGINT       NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    event_name      VARCHAR(200) NOT NULL,
+    source_class    VARCHAR(500) NOT NULL,
+    source_method   VARCHAR(200) NOT NULL,
+    parameter_names JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    app_version     VARCHAR(100),
+    status          VARCHAR(20)  NOT NULL DEFAULT 'DISCOVERED',
+    first_seen_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    last_seen_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT uk_discovered_log_events_source
+        UNIQUE (agent_id, event_name, source_class, source_method)
+);
+
+CREATE INDEX idx_discovered_log_events_agent_status
+    ON discovered_log_events(agent_id, status);
+
+CREATE INDEX idx_discovered_log_events_event_name
+    ON discovered_log_events(event_name);

--- a/src/test/kotlin/com/logfriends/platform/api/rest/AgentControllerTest.kt
+++ b/src/test/kotlin/com/logfriends/platform/api/rest/AgentControllerTest.kt
@@ -1,0 +1,77 @@
+package com.logfriends.platform.api.rest
+
+import com.logfriends.platform.api.dto.AgentRegisterRequest
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.entity.AgentStatus
+import com.logfriends.platform.domain.agent.service.AgentService
+import com.logfriends.platform.domain.logspec.entity.LogSpecSnapshot
+import com.logfriends.platform.domain.logspec.service.LogSpecService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.springframework.http.HttpStatus
+import org.springframework.test.util.ReflectionTestUtils
+
+class AgentControllerTest {
+
+    private val agentService: AgentService = mock()
+    private val logSpecService: LogSpecService = mock()
+    private val controller = AgentController(agentService, logSpecService)
+
+    @Test
+    fun `registerAgent returns appName based known LogSpecs for SDK handshake`() {
+        val agent = Agent(
+            workerId = "order-service-local-1",
+            appName = "order-service",
+            metadata = mapOf("env" to "local"),
+            status = AgentStatus.RUNNING
+        )
+        ReflectionTestUtils.setField(agent, "id", 1L)
+
+        val orderCreated = logSpec("orderCreated")
+        val orderCancelled = logSpec("orderCancelled")
+        val duplicatedOrderCreated = logSpec("orderCreated")
+
+        given(
+            agentService.register(
+                workerId = "order-service-local-1",
+                appName = "order-service",
+                sdkVersion = "0.1.0",
+                javaVersion = "21",
+                hostname = "local",
+                metadata = mapOf("env" to "local")
+            )
+        ).willReturn(agent)
+        given(logSpecService.findAllByAppName("order-service"))
+            .willReturn(listOf(orderCreated, orderCancelled, duplicatedOrderCreated))
+
+        val response = controller.registerAgent(
+            AgentRegisterRequest(
+                workerId = "order-service-local-1",
+                appName = "order-service",
+                sdkVersion = "0.1.0",
+                javaVersion = "21",
+                hostname = "local",
+                metadata = mapOf("env" to "local")
+            )
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(response.body!!.agentId).isEqualTo(1L)
+        assertThat(response.body!!.workerId).isEqualTo("order-service-local-1")
+        assertThat(response.body!!.appName).isEqualTo("order-service")
+        assertThat(response.body!!.knownLogSpecs.map { it.eventName })
+            .containsExactly("orderCancelled", "orderCreated")
+    }
+
+    private fun logSpec(eventName: String): LogSpecSnapshot {
+        val spec = LogSpecSnapshot(
+            agentId = 1L,
+            specName = eventName,
+            description = "$eventName description"
+        )
+        ReflectionTestUtils.setField(spec, "id", eventName.hashCode().toLong())
+        return spec
+    }
+}

--- a/src/test/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventServiceTest.kt
+++ b/src/test/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventServiceTest.kt
@@ -1,0 +1,211 @@
+package com.logfriends.platform.domain.discoveredlogevent.service
+
+import com.logfriends.platform.api.dto.DiscoveredLogEventItemRequest
+import com.logfriends.platform.api.dto.DiscoveredLogEventReportRequest
+import com.logfriends.platform.common.exception.BusinessException
+import com.logfriends.platform.common.exception.ErrorCode
+import com.logfriends.platform.domain.agent.entity.Agent
+import com.logfriends.platform.domain.agent.repository.AgentRepository
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEvent
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEventStatus
+import com.logfriends.platform.domain.discoveredlogevent.repository.DiscoveredLogEventRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.test.util.ReflectionTestUtils
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class DiscoveredLogEventServiceTest {
+
+    private val agentRepository: AgentRepository = mock()
+    private val discoveredLogEventRepository: DiscoveredLogEventRepository = mock()
+    private val service = DiscoveredLogEventService(agentRepository, discoveredLogEventRepository)
+
+    @Test
+    fun `report creates discovered log event candidates`() {
+        val agent = agent(id = 1L)
+        given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
+        given(
+            discoveredLogEventRepository.findByAgentIdAndEventNameAndSourceClassAndSourceMethod(
+                1L,
+                "orderCreated",
+                "com.example.OrderService",
+                "createOrder"
+            )
+        ).willReturn(Optional.empty())
+        given(discoveredLogEventRepository.save(any(DiscoveredLogEvent::class.java))).willAnswer { it.arguments[0] }
+
+        val response = service.report(
+            agentId = 1L,
+            request = DiscoveredLogEventReportRequest(
+                workerId = "order-service-local-1",
+                appName = "order-service",
+                appVersion = "0.1.0",
+                events = listOf(
+                    DiscoveredLogEventItemRequest(
+                        eventName = "orderCreated",
+                        sourceClass = "com.example.OrderService",
+                        sourceMethod = "createOrder",
+                        parameterNames = listOf("request")
+                    )
+                )
+            )
+        )
+
+        assertThat(response.received).isEqualTo(1)
+        assertThat(response.upserted).isEqualTo(1)
+        verify(discoveredLogEventRepository).save(any(DiscoveredLogEvent::class.java))
+    }
+
+    @Test
+    fun `report refreshes existing candidate without resetting ignored status`() {
+        val agent = agent(id = 1L)
+        val existing = DiscoveredLogEvent(
+            agent = agent,
+            eventName = "orderCreated",
+            sourceClass = "com.example.OrderService",
+            sourceMethod = "createOrder",
+            parameterNames = listOf("oldRequest"),
+            status = DiscoveredLogEventStatus.IGNORED
+        )
+        given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
+        given(
+            discoveredLogEventRepository.findByAgentIdAndEventNameAndSourceClassAndSourceMethod(
+                1L,
+                "orderCreated",
+                "com.example.OrderService",
+                "createOrder"
+            )
+        ).willReturn(Optional.of(existing))
+        given(discoveredLogEventRepository.save(existing)).willReturn(existing)
+
+        service.report(
+            agentId = 1L,
+            request = DiscoveredLogEventReportRequest(
+                workerId = "order-service-local-1",
+                appName = "order-service",
+                appVersion = "0.1.1",
+                events = listOf(
+                    DiscoveredLogEventItemRequest(
+                        eventName = "orderCreated",
+                        sourceClass = "com.example.OrderService",
+                        sourceMethod = "createOrder",
+                        parameterNames = listOf("request")
+                    )
+                )
+            )
+        )
+
+        assertThat(existing.parameterNames).containsExactly("request")
+        assertThat(existing.appVersion).isEqualTo("0.1.1")
+        assertThat(existing.status).isEqualTo(DiscoveredLogEventStatus.IGNORED)
+    }
+
+    @Test
+    fun `report accepts empty events`() {
+        val agent = agent(id = 1L)
+        given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
+
+        val response = service.report(
+            agentId = 1L,
+            request = DiscoveredLogEventReportRequest(
+                workerId = "order-service-local-1",
+                appName = "order-service",
+                events = emptyList()
+            )
+        )
+
+        assertThat(response.received).isZero()
+        assertThat(response.upserted).isZero()
+        verify(discoveredLogEventRepository, never()).save(any(DiscoveredLogEvent::class.java))
+    }
+
+    @Test
+    fun `report rejects agent identity mismatch`() {
+        val agent = agent(id = 1L)
+        given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
+
+        assertThatThrownBy {
+            service.report(
+                agentId = 1L,
+                request = DiscoveredLogEventReportRequest(
+                    workerId = "other-worker",
+                    appName = "order-service",
+                    events = emptyList()
+                )
+            )
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CONFLICT)
+    }
+
+    @Test
+    fun `report rejects non camelCase eventName`() {
+        val agent = agent(id = 1L)
+        given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
+
+        assertThatThrownBy {
+            service.report(
+                agentId = 1L,
+                request = DiscoveredLogEventReportRequest(
+                    workerId = "order-service-local-1",
+                    appName = "order-service",
+                    events = listOf(
+                        DiscoveredLogEventItemRequest(
+                            eventName = "OrderCreated",
+                            sourceClass = "com.example.OrderService",
+                            sourceMethod = "createOrder"
+                        )
+                    )
+                )
+            )
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.INVALID_REQUEST)
+    }
+
+    @Test
+    fun `report rejects more than 500 events`() {
+        val agent = agent(id = 1L)
+        given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
+        val events = (1..501).map {
+            DiscoveredLogEventItemRequest(
+                eventName = "orderCreated$it",
+                sourceClass = "com.example.OrderService",
+                sourceMethod = "createOrder"
+            )
+        }
+
+        assertThatThrownBy {
+            service.report(
+                agentId = 1L,
+                request = DiscoveredLogEventReportRequest(
+                    workerId = "order-service-local-1",
+                    appName = "order-service",
+                    events = events
+                )
+            )
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.INVALID_REQUEST)
+    }
+
+    private fun agent(id: Long): Agent =
+        Agent(
+            workerId = "order-service-local-1",
+            appName = "order-service"
+        ).also {
+            ReflectionTestUtils.setField(it, "id", id)
+        }
+}


### PR DESCRIPTION
## Summary
- Add a registration-specific response for POST /api/agents
- Include agentId, workerId, appName, and appName-based knownLogSpecs
- Keep list/get/heartbeat responses on the existing AgentResponse shape
- Add a controller unit test for knownLogSpecs de-duplication and ordering

Closes #15

## Verification
- ./gradlew clean test
- ./gradlew build