### PR TITLE
Show discovered LogSpec hints in Log Catalog

### DIFF
--- a/src/main/kotlin/com/logfriends/platform/api/dto/DiscoveredLogEventDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/DiscoveredLogEventDto.kt
@@ -20,7 +20,8 @@ data class DiscoveredLogEventItemRequest(
     val eventName: String,
     val sourceClass: String,
     val sourceMethod: String,
-    val parameterNames: List<String> = emptyList()
+    val parameterNames: List<String> = emptyList(),
+    val specHint: Map<String, Any?>? = null
 )
 
 data class DiscoveredLogEventReportResponse(
@@ -35,6 +36,7 @@ data class DiscoveredLogEventResponse(
     val sourceClass: String,
     val sourceMethod: String,
     val parameterNames: List<String>,
+    val specHint: Map<String, Any?>?,
     val appVersion: String?,
     val status: DiscoveredLogEventStatus,
     val firstSeenAt: Instant,
@@ -50,6 +52,7 @@ data class DiscoveredLogEventResponse(
             sourceClass = discoveredLogEvent.sourceClass,
             sourceMethod = discoveredLogEvent.sourceMethod,
             parameterNames = discoveredLogEvent.parameterNames,
+            specHint = discoveredLogEvent.specHint,
             appVersion = discoveredLogEvent.appVersion,
             status = discoveredLogEvent.status,
             firstSeenAt = discoveredLogEvent.firstSeenAt,

--- a/src/main/kotlin/com/logfriends/platform/api/dto/LogCatalogDto.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/dto/LogCatalogDto.kt
@@ -37,10 +37,18 @@ data class LogCatalogEventResponse(
     val description: String?,
     val apiContext: LogCatalogApiContextResponse?,
     val specStatus: LogCatalogSpecStatus,
+    val discoveredHints: List<LogCatalogDiscoveredHintResponse>,
     val fields: List<LogCatalogFieldResponse>,
     val samples: List<LogCatalogSampleResponse>,
     val mismatches: List<LogCatalogMismatchResponse>,
     val fieldRequests: List<FieldRequestResponse>
+)
+
+data class LogCatalogDiscoveredHintResponse(
+    val sourceClass: String,
+    val sourceMethod: String,
+    val appVersion: String?,
+    val specHint: Map<String, Any?>?
 )
 
 data class LogCatalogApiContextResponse(

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/entity/DiscoveredLogEvent.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/entity/DiscoveredLogEvent.kt
@@ -49,6 +49,10 @@ class DiscoveredLogEvent(
     @Column(name = "parameter_names", columnDefinition = "jsonb", nullable = false)
     var parameterNames: List<String> = emptyList(),
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "spec_hint", columnDefinition = "jsonb")
+    var specHint: Map<String, Any?>? = null,
+
     @Column(name = "app_version")
     var appVersion: String? = null,
 
@@ -65,10 +69,12 @@ class DiscoveredLogEvent(
 
     fun refresh(
         parameterNames: List<String>,
+        specHint: Map<String, Any?>?,
         appVersion: String?,
         observedAt: Instant = Instant.now()
     ) {
         this.parameterNames = parameterNames
+        this.specHint = specHint
         this.appVersion = appVersion
         this.lastSeenAt = observedAt
     }

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/repository/DiscoveredLogEventRepository.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/repository/DiscoveredLogEventRepository.kt
@@ -14,4 +14,6 @@ interface DiscoveredLogEventRepository : JpaRepository<DiscoveredLogEvent, Long>
     ): Optional<DiscoveredLogEvent>
 
     fun findAllByAgentIdOrderByEventNameAscSourceClassAscSourceMethodAsc(agentId: Long): List<DiscoveredLogEvent>
+
+    fun findAllByAgentIdInOrderByEventNameAscSourceClassAscSourceMethodAsc(agentIds: Collection<Long>): List<DiscoveredLogEvent>
 }

--- a/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventService.kt
@@ -60,6 +60,7 @@ class DiscoveredLogEventService(
             .map {
                 it.refresh(
                     parameterNames = event.parameterNames,
+                    specHint = event.specHint,
                     appVersion = appVersion,
                     observedAt = observedAt
                 )
@@ -72,6 +73,7 @@ class DiscoveredLogEventService(
                     sourceClass = event.sourceClass,
                     sourceMethod = event.sourceMethod,
                     parameterNames = event.parameterNames,
+                    specHint = event.specHint,
                     appVersion = appVersion,
                     firstSeenAt = observedAt,
                     lastSeenAt = observedAt

--- a/src/main/kotlin/com/logfriends/platform/domain/logcatalog/service/LogCatalogService.kt
+++ b/src/main/kotlin/com/logfriends/platform/domain/logcatalog/service/LogCatalogService.kt
@@ -7,6 +7,8 @@ import com.logfriends.platform.common.exception.BusinessException
 import com.logfriends.platform.common.exception.ErrorCode
 import com.logfriends.platform.domain.agent.entity.Agent
 import com.logfriends.platform.domain.agent.repository.AgentRepository
+import com.logfriends.platform.domain.discoveredlogevent.entity.DiscoveredLogEvent
+import com.logfriends.platform.domain.discoveredlogevent.repository.DiscoveredLogEventRepository
 import com.logfriends.platform.domain.fieldrequest.entity.FieldRequestStatus
 import com.logfriends.platform.domain.fieldrequest.entity.FieldType
 import com.logfriends.platform.domain.fieldrequest.repository.FieldRequestRepository
@@ -22,6 +24,7 @@ import java.time.Instant
 class LogCatalogService(
     private val agentRepository: AgentRepository,
     private val logSpecSnapshotRepository: LogSpecSnapshotRepository,
+    private val discoveredLogEventRepository: DiscoveredLogEventRepository,
     private val fieldRequestRepository: FieldRequestRepository,
     private val dsl: DSLContext,
     private val objectMapper: ObjectMapper
@@ -52,12 +55,16 @@ class LogCatalogService(
         }
 
         val targetWorkerIds = selectedWorkerId?.let { listOf(it) } ?: workerIds
+        val targetAgents = selectedWorkerId
+            ?.let { worker -> agents.filter { it.workerId == worker } }
+            ?: agents
+        val discoveredHintsByEventName = fetchDiscoveredHints(targetAgents).groupBy { it.eventName }
         val specs = logSpecSnapshotRepository.findAllByAppName(appName)
             .groupBy { it.specName }
             .mapValues { (_, grouped) -> grouped.maxBy { it.updatedAt } }
         val samples = fetchSamples(targetWorkerIds, normalizeSampleSize(sampleSize))
         val samplesByEventName = samples.groupBy { it.eventName }
-        val eventNames = (specs.keys + samplesByEventName.keys).sorted()
+        val eventNames = (specs.keys + samplesByEventName.keys + discoveredHintsByEventName.keys).sorted()
         val requestsByEventName = if (eventNames.isEmpty()) {
             emptyMap()
         } else {
@@ -81,6 +88,7 @@ class LogCatalogService(
                     eventSamples.isEmpty() -> LogCatalogSpecStatus.NO_SAMPLE
                     else -> LogCatalogSpecStatus.REGISTERED
                 },
+                discoveredHints = discoveredHintsByEventName[eventName].orEmpty().map { it.toDiscoveredHintResponse() },
                 fields = fields,
                 samples = eventSamples.map {
                     LogCatalogSampleResponse(
@@ -111,6 +119,20 @@ class LogCatalogService(
         if (method == null && path == null && description == null) return null
         return LogCatalogApiContextResponse(method, path, description)
     }
+
+    private fun fetchDiscoveredHints(agents: List<Agent>): List<DiscoveredLogEvent> {
+        val agentIds = agents.mapNotNull { it.id }
+        if (agentIds.isEmpty()) return emptyList()
+        return discoveredLogEventRepository.findAllByAgentIdInOrderByEventNameAscSourceClassAscSourceMethodAsc(agentIds)
+    }
+
+    private fun DiscoveredLogEvent.toDiscoveredHintResponse(): LogCatalogDiscoveredHintResponse =
+        LogCatalogDiscoveredHintResponse(
+            sourceClass = sourceClass,
+            sourceMethod = sourceMethod,
+            appVersion = appVersion,
+            specHint = specHint
+        )
 
     private fun agentsForApp(appName: String): List<Agent> {
         val normalized = appName.trim()

--- a/src/main/resources/db/migration/V11__add_discovered_log_event_spec_hint.sql
+++ b/src/main/resources/db/migration/V11__add_discovered_log_event_spec_hint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE discovered_log_events
+    ADD COLUMN spec_hint JSONB;

--- a/src/main/resources/static/log-catalog.css
+++ b/src/main/resources/static/log-catalog.css
@@ -171,7 +171,8 @@ input {
 
 .badges,
 .fields,
-.requests {
+.requests,
+.hint-fields {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -190,6 +191,27 @@ input {
 .field-row {
   display: grid;
   gap: 4px;
+}
+
+.hint-card {
+  border: 1px solid #d9e0e8;
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+}
+
+.hints {
+  display: grid;
+  gap: 10px;
+}
+
+.hint-nested {
+  border-left: 2px solid #d9e0e8;
+  display: grid;
+  gap: 6px;
+  margin-top: 4px;
+  padding-left: 10px;
 }
 
 .badge.warn {

--- a/src/main/resources/static/log-catalog.html
+++ b/src/main/resources/static/log-catalog.html
@@ -64,6 +64,11 @@
       </section>
 
       <section>
+        <h3>LogSpec Hints</h3>
+        <div class="hints"></div>
+      </section>
+
+      <section>
         <h3>Recent Sample</h3>
         <div class="samples"></div>
       </section>

--- a/src/main/resources/static/log-catalog.js
+++ b/src/main/resources/static/log-catalog.js
@@ -106,11 +106,53 @@ function renderEvents() {
     node.querySelector(".description").textContent = event.description || "";
     renderBadges(node.querySelector(".badges"), event);
     renderFields(node.querySelector(".fields"), event.fields || []);
+    renderHints(node.querySelector(".hints"), event.discoveredHints || []);
     renderSamples(node.querySelector(".samples"), event.samples || []);
     renderRequests(node.querySelector(".requests"), event);
     bindRequestForm(node.querySelector(".request-form"), node.querySelector(".toggle-request-form"), event);
     els.events.appendChild(node);
   }
+}
+
+function renderHints(container, hints) {
+  if (hints.length === 0) {
+    container.innerHTML = `<span class="field">No annotation hint</span>`;
+    return;
+  }
+
+  container.innerHTML = hints.map((hint) => {
+    const specHint = hint.specHint || {};
+    const source = `${hint.sourceClass}.${hint.sourceMethod}`;
+    const api = [specHint.apiMethod, specHint.apiPath].filter(Boolean).join(" ");
+    const fields = Array.isArray(specHint.fields) ? specHint.fields : [];
+    return `
+      <div class="hint-card">
+        <p class="api-endpoint">${escapeHtml(source)}</p>
+        ${hint.appVersion ? `<p class="description">appVersion ${escapeHtml(hint.appVersion)}</p>` : ""}
+        ${api ? `<p class="api-endpoint">${escapeHtml(api)}</p>` : ""}
+        ${specHint.apiDescription ? `<p class="api-description">${escapeHtml(specHint.apiDescription)}</p>` : ""}
+        ${specHint.description ? `<p class="description">${escapeHtml(specHint.description)}</p>` : ""}
+        <div class="hint-fields">${renderHintFields(fields)}</div>
+      </div>
+    `;
+  }).join("");
+}
+
+function renderHintFields(fields) {
+  if (fields.length === 0) return `<span class="field">No field hint</span>`;
+  return fields.map((field) => {
+    const required = field.required === false ? "optional" : "required";
+    const nested = Array.isArray(field.nestedFields) && field.nestedFields.length > 0
+      ? `<div class="hint-nested">${renderHintFields(field.nestedFields)}</div>`
+      : "";
+    return `
+      <div class="field-row">
+        <span class="field">${escapeHtml(field.name)} · ${escapeHtml(field.type || "STRING")} · ${required}</span>
+        ${field.description ? `<p class="field-description">${escapeHtml(field.description)}</p>` : ""}
+        ${nested}
+      </div>
+    `;
+  }).join("");
 }
 
 function renderStats() {

--- a/src/test/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventServiceTest.kt
+++ b/src/test/kotlin/com/logfriends/platform/domain/discoveredlogevent/service/DiscoveredLogEventServiceTest.kt
@@ -54,7 +54,16 @@ class DiscoveredLogEventServiceTest {
                         eventName = "orderCreated",
                         sourceClass = "com.example.OrderService",
                         sourceMethod = "createOrder",
-                        parameterNames = listOf("request")
+                        parameterNames = listOf("request"),
+                        specHint = mapOf(
+                            "description" to "Order creation business eventName",
+                            "fields" to listOf(
+                                mapOf(
+                                    "name" to "request",
+                                    "description" to "OrderRequest DTO object"
+                                )
+                            )
+                        )
                     )
                 )
             )
@@ -74,6 +83,7 @@ class DiscoveredLogEventServiceTest {
             sourceClass = "com.example.OrderService",
             sourceMethod = "createOrder",
             parameterNames = listOf("oldRequest"),
+            specHint = mapOf("description" to "old description"),
             status = DiscoveredLogEventStatus.IGNORED
         )
         given(agentRepository.findById(1L)).willReturn(Optional.of(agent))
@@ -98,13 +108,15 @@ class DiscoveredLogEventServiceTest {
                         eventName = "orderCreated",
                         sourceClass = "com.example.OrderService",
                         sourceMethod = "createOrder",
-                        parameterNames = listOf("request")
+                        parameterNames = listOf("request"),
+                        specHint = mapOf("description" to "new description")
                     )
                 )
             )
         )
 
         assertThat(existing.parameterNames).containsExactly("request")
+        assertThat(existing.specHint).containsEntry("description", "new description")
         assertThat(existing.appVersion).isEqualTo("0.1.1")
         assertThat(existing.status).isEqualTo(DiscoveredLogEventStatus.IGNORED)
     }


### PR DESCRIPTION
## Summary
- store SDK-provided `specHint` JSON on discovered LogEvent records
- include discovered hints in Log Catalog responses across selected app/workers
- render annotation hints in the static Log Catalog UI

## Why
`eventName` and field names are useful, but they still leave data engineers guessing. This lets Console show backend-provided annotation hints without auto-promoting them to LogSpec.

## Validation
- `./gradlew build`

## Notes
- Local `.env`, `.vscode`, and `bin/` changes were intentionally excluded from this PR.
