### PR TITLE
Add raw events CSV view

### DIFF
--- a/src/main/kotlin/com/logfriends/platform/api/rest/EventQueryController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/EventQueryController.kt
@@ -1,6 +1,8 @@
 package com.logfriends.platform.api.rest
 
 import com.logfriends.platform.infrastructure.query.EventQueryService
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.time.Instant
@@ -39,12 +41,27 @@ class EventQueryController(
 
     @GetMapping("/custom")
     fun queryCustom(
+        @RequestParam(required = false) appName: String?,
+        @RequestParam(required = false) workerId: String?,
+        @RequestParam(required = false) eventName: String?,
+        @RequestParam from: Instant,
+        @RequestParam to: Instant,
+        @RequestParam(required = false, defaultValue = "100") limit: Int
+    ): ResponseEntity<List<Map<String, Any?>>> =
+        ResponseEntity.ok(eventQueryService.queryCustomEvents(appName, workerId, eventName, from, to, limit.coerceIn(1, 500)))
+
+    @GetMapping("/custom.csv", produces = ["text/csv"])
+    fun exportCustomCsv(
+        @RequestParam(required = false) appName: String?,
         @RequestParam(required = false) workerId: String?,
         @RequestParam(required = false) eventName: String?,
         @RequestParam from: Instant,
         @RequestParam to: Instant
-    ): ResponseEntity<List<Map<String, Any?>>> =
-        ResponseEntity.ok(eventQueryService.queryCustomEvents(workerId, eventName, from, to))
+    ): ResponseEntity<String> =
+        ResponseEntity.ok()
+            .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"log-friends-custom-events.csv\"")
+            .body(eventQueryService.queryCustomEventsCsv(appName, workerId, eventName, from, to))
 
     @GetMapping("/method-trace")
     fun queryMethodTrace(

--- a/src/main/kotlin/com/logfriends/platform/api/rest/StaticPageController.kt
+++ b/src/main/kotlin/com/logfriends/platform/api/rest/StaticPageController.kt
@@ -11,4 +11,7 @@ class StaticPageController {
 
     @GetMapping("/log-catalog")
     fun logCatalog(): String = "forward:/log-catalog.html"
+
+    @GetMapping("/raw-events")
+    fun rawEvents(): String = "forward:/raw-events.html"
 }

--- a/src/main/kotlin/com/logfriends/platform/infrastructure/query/EventQueryService.kt
+++ b/src/main/kotlin/com/logfriends/platform/infrastructure/query/EventQueryService.kt
@@ -74,22 +74,67 @@ class EventQueryService(
 
     /** @LogEvent 커스텀 이벤트 조회 */
     fun queryCustomEvents(
+        appName: String?,
+        workerId: String?,
+        eventName: String?,
+        from: Instant,
+        to: Instant,
+        limit: Int? = null
+    ): List<Map<String, Any?>> {
+        val conditions = mutableListOf(
+            DSL.field("c.ts").ge(from),
+            DSL.field("c.ts").lt(to)
+        )
+        appName?.let { conditions.add(DSL.field("a.app_name").eq(it)) }
+        workerId?.let { conditions.add(DSL.field("c.worker_id").eq(it)) }
+        eventName?.let { conditions.add(DSL.field("c.event_name").eq(it)) }
+
+        val query = dsl.select(
+            DSL.field("c.id").`as`("id"),
+            DSL.field("a.app_name").`as`("appName"),
+            DSL.field("c.worker_id").`as`("workerId"),
+            DSL.field("c.ts").`as`("timestamp"),
+            DSL.inline("LOG_EVENT").`as`("eventType"),
+            DSL.field("c.event_name").`as`("eventName"),
+            DSL.field("c.payload").`as`("payload")
+        )
+            .from(DSL.table("custom_events").`as`("c"))
+            .leftJoin(DSL.table("agents").`as`("a"))
+            .on(DSL.field("a.worker_id").eq(DSL.field("c.worker_id")))
+            .where(conditions)
+            .orderBy(DSL.field("c.ts").desc(), DSL.field("c.id").desc())
+
+        return if (limit != null) {
+            query.limit(limit).fetchMaps()
+        } else {
+            query.fetchMaps()
+        }
+    }
+
+    fun queryCustomEventsCsv(
+        appName: String?,
         workerId: String?,
         eventName: String?,
         from: Instant,
         to: Instant
-    ): List<Map<String, Any?>> {
-        val conditions = mutableListOf(
-            DSL.field("ts").between(from, to)
-        )
-        workerId?.let { conditions.add(DSL.field("worker_id").eq(it)) }
-        eventName?.let { conditions.add(DSL.field("event_name").eq(it)) }
-
-        return dsl.select()
-            .from(DSL.table("custom_events"))
-            .where(conditions)
-            .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
-            .fetchMaps()
+    ): String {
+        val rows = queryCustomEvents(appName, workerId, eventName, from, to, null)
+        val header = listOf("timestamp", "appName", "workerId", "eventType", "eventName", "payloadJson")
+        return buildString {
+            appendLine(header.joinToString(","))
+            rows.forEach { row ->
+                appendLine(
+                    listOf(
+                        row["timestamp"],
+                        row["appName"],
+                        row["workerId"],
+                        row["eventType"],
+                        row["eventName"],
+                        row["payload"]
+                    ).joinToString(",") { csvEscape(it?.toString().orEmpty()) }
+                )
+            }
+        }
     }
 
     /** METHOD_TRACE 이벤트 조회 */
@@ -113,4 +158,9 @@ class EventQueryService(
             .orderBy(DSL.field("ts").asc(), DSL.field("id").asc())
             .fetchMaps()
     }
+}
+
+private fun csvEscape(value: String): String {
+    val escaped = value.replace("\"", "\"\"")
+    return "\"$escaped\""
 }

--- a/src/main/resources/static/log-catalog.css
+++ b/src/main/resources/static/log-catalog.css
@@ -33,6 +33,21 @@ button:hover {
   background: #f0f4f8;
 }
 
+.button-link {
+  align-items: center;
+  border: 1px solid #c9d1dd;
+  border-radius: 6px;
+  color: #18202f;
+  display: inline-flex;
+  min-height: 36px;
+  padding: 0 12px;
+  text-decoration: none;
+}
+
+.button-link:hover {
+  background: #f0f4f8;
+}
+
 .shell {
   max-width: 1200px;
   margin: 0 auto;
@@ -79,6 +94,22 @@ p {
   padding: 14px;
 }
 
+.raw-toolbar {
+  grid-template-columns: repeat(3, minmax(150px, 1fr)) repeat(2, minmax(240px, 1fr)) 100px;
+}
+
+.toolbar-actions {
+  align-items: end;
+  display: flex;
+  gap: 8px;
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+}
+
+.toolbar-actions button {
+  min-width: 96px;
+}
+
 label {
   color: #596579;
   display: grid;
@@ -105,6 +136,64 @@ input {
 .events {
   display: grid;
   gap: 14px;
+}
+
+.catalog-layout {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.api-list {
+  display: grid;
+  gap: 8px;
+}
+
+.api-item {
+  align-items: stretch;
+  display: grid;
+  gap: 5px;
+  min-height: auto;
+  padding: 12px;
+  text-align: left;
+}
+
+.api-item.selected {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 1px #2563eb inset;
+}
+
+.api-item-title {
+  color: #1f2937;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 13px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.api-item-event {
+  color: #18202f;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.api-item-source {
+  color: #596579;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.api-item-meta {
+  color: #596579;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.api-detail {
+  min-width: 0;
 }
 
 .stats {
@@ -134,6 +223,11 @@ input {
   display: grid;
   gap: 18px;
   padding: 18px;
+}
+
+.event-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .event-head,
@@ -241,6 +335,46 @@ pre {
   white-space: pre-wrap;
 }
 
+.raw-table-wrap {
+  background: #ffffff;
+  border: 1px solid #d9e0e8;
+  border-radius: 8px;
+  overflow: auto;
+}
+
+.raw-table {
+  border-collapse: collapse;
+  min-width: 980px;
+  width: 100%;
+}
+
+.raw-table th,
+.raw-table td {
+  border-bottom: 1px solid #e5eaf0;
+  padding: 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.raw-table th {
+  color: #596579;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.raw-table td {
+  color: #334155;
+  font-size: 13px;
+}
+
+.raw-table pre {
+  max-height: 220px;
+}
+
+.empty-cell {
+  text-align: center;
+}
+
 .request-form {
   display: grid;
   grid-template-columns: minmax(160px, 1fr) 130px minmax(180px, 1.5fr) minmax(140px, 1fr) auto;
@@ -286,7 +420,14 @@ pre {
   }
 
   .toolbar,
-  .request-form {
+  .raw-toolbar,
+  .request-form,
+  .catalog-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar-actions {
+    display: grid;
     grid-template-columns: 1fr;
   }
 }

--- a/src/main/resources/static/log-catalog.html
+++ b/src/main/resources/static/log-catalog.html
@@ -58,6 +58,8 @@
         <div class="badges"></div>
       </header>
 
+      <div class="event-actions"></div>
+
       <section>
         <h3>Spec</h3>
         <div class="fields"></div>

--- a/src/main/resources/static/log-catalog.js
+++ b/src/main/resources/static/log-catalog.js
@@ -6,7 +6,8 @@ const state = {
   events: [],
   eventTypeSummaries: [],
   failureSummaries: [],
-  search: ""
+  search: "",
+  selectedCatalogItemKey: ""
 };
 
 const els = {
@@ -91,27 +92,142 @@ function renderWorkerSelect(workerIds) {
 
 function renderEvents() {
   const query = state.search.trim().toLowerCase();
-  const events = state.events.filter((event) => event.eventName.toLowerCase().includes(query));
+  const items = buildCatalogItems(state.events)
+    .filter((item) => matchesCatalogSearch(item, query));
   els.events.innerHTML = "";
 
-  if (events.length === 0) {
-    els.events.innerHTML = `<p class="message">No catalog event.</p>`;
+  if (items.length === 0) {
+    els.events.innerHTML = `<p class="message">No API event.</p>`;
     return;
   }
 
-  for (const event of events) {
-    const node = els.template.content.cloneNode(true);
-    node.querySelector("h2").textContent = event.eventName;
-    renderApiContext(node.querySelector(".api-context"), event.apiContext);
-    node.querySelector(".description").textContent = event.description || "";
-    renderBadges(node.querySelector(".badges"), event);
-    renderFields(node.querySelector(".fields"), event.fields || []);
-    renderHints(node.querySelector(".hints"), event.discoveredHints || []);
-    renderSamples(node.querySelector(".samples"), event.samples || []);
-    renderRequests(node.querySelector(".requests"), event);
-    bindRequestForm(node.querySelector(".request-form"), node.querySelector(".toggle-request-form"), event);
-    els.events.appendChild(node);
+  if (!items.some((item) => item.key === state.selectedCatalogItemKey)) {
+    state.selectedCatalogItemKey = items[0].key;
   }
+
+  const layout = document.createElement("div");
+  layout.className = "catalog-layout";
+
+  const list = document.createElement("section");
+  list.className = "api-list";
+  list.setAttribute("aria-label", "API events");
+  list.innerHTML = items.map((item) => renderCatalogItemButton(item)).join("");
+
+  const detail = document.createElement("section");
+  detail.className = "api-detail";
+  detail.setAttribute("aria-live", "polite");
+
+  layout.appendChild(list);
+  layout.appendChild(detail);
+  els.events.appendChild(layout);
+
+  list.querySelectorAll("button[data-item-key]").forEach((button) => {
+    button.addEventListener("click", () => {
+      state.selectedCatalogItemKey = button.dataset.itemKey;
+      renderEvents();
+    });
+  });
+
+  const selected = items.find((item) => item.key === state.selectedCatalogItemKey) || items[0];
+  renderCatalogDetail(detail, selected);
+}
+
+function buildCatalogItems(events) {
+  return events.flatMap((event) => {
+    const hints = Array.isArray(event.discoveredHints) ? event.discoveredHints : [];
+    if (hints.length === 0) {
+      return [createCatalogItem(event, null, 0)];
+    }
+    return hints.map((hint, index) => createCatalogItem(event, hint, index));
+  });
+}
+
+function createCatalogItem(event, hint, index) {
+  const specHint = hint?.specHint || {};
+  const apiMethod = specHint.apiMethod || event.apiContext?.method || "";
+  const apiPath = specHint.apiPath || event.apiContext?.path || "";
+  const api = [apiMethod, apiPath].filter(Boolean).join(" ");
+  const source = hint ? `${hint.sourceClass}.${hint.sourceMethod}` : "";
+  const title = api || event.eventName;
+  const subtitle = source || event.description || "No API hint";
+  const key = [
+    event.eventName,
+    apiMethod,
+    apiPath,
+    hint?.sourceClass,
+    hint?.sourceMethod,
+    hint?.appVersion,
+    index
+  ].filter(Boolean).join("::");
+
+  return { key, event, hint, title, subtitle };
+}
+
+function matchesCatalogSearch(item, query) {
+  if (!query) return true;
+  return [
+    item.event.eventName,
+    item.title,
+    item.subtitle,
+    item.event.specStatus
+  ].some((value) => String(value || "").toLowerCase().includes(query));
+}
+
+function renderCatalogItemButton(item) {
+  const selected = item.key === state.selectedCatalogItemKey ? "selected" : "";
+  const appVersion = item.hint?.appVersion ? `<span>${escapeHtml(item.hint.appVersion)}</span>` : "";
+  return `
+    <button class="api-item ${selected}" type="button" data-item-key="${escapeHtml(item.key)}">
+      <span class="api-item-title">${escapeHtml(item.title)}</span>
+      <span class="api-item-event">${escapeHtml(item.event.eventName)}</span>
+      <span class="api-item-source">${escapeHtml(item.subtitle)}</span>
+      <span class="api-item-meta">
+        <span>${escapeHtml(item.event.specStatus)}</span>
+        ${appVersion}
+      </span>
+    </button>
+  `;
+}
+
+function renderCatalogDetail(container, item) {
+  const event = item.event;
+  const node = els.template.content.cloneNode(true);
+  node.querySelector("h2").textContent = event.eventName;
+  renderApiContext(node.querySelector(".api-context"), apiContextForItem(item));
+  node.querySelector(".description").textContent = descriptionForItem(item);
+  renderBadges(node.querySelector(".badges"), event);
+  renderEventActions(node.querySelector(".event-actions"), event);
+  renderFields(node.querySelector(".fields"), event.fields || []);
+  renderHints(node.querySelector(".hints"), item.hint ? [item.hint] : event.discoveredHints || []);
+  renderSamples(node.querySelector(".samples"), event.samples || []);
+  renderRequests(node.querySelector(".requests"), event);
+  bindRequestForm(node.querySelector(".request-form"), node.querySelector(".toggle-request-form"), event);
+  container.replaceChildren(node);
+}
+
+function renderEventActions(container, event) {
+  const params = new URLSearchParams();
+  if (state.selectedApp) params.set("appName", state.selectedApp);
+  if (state.selectedWorker) params.set("workerId", state.selectedWorker);
+  params.set("eventType", "LOG_EVENT");
+  params.set("eventName", event.eventName);
+  container.innerHTML = `<a class="button-link" href="/raw-events?${params.toString()}">View Logs / CSV</a>`;
+}
+
+function apiContextForItem(item) {
+  const specHint = item.hint?.specHint || {};
+  if (specHint.apiMethod || specHint.apiPath || specHint.apiDescription) {
+    return {
+      method: specHint.apiMethod,
+      path: specHint.apiPath,
+      description: specHint.apiDescription
+    };
+  }
+  return item.event.apiContext;
+}
+
+function descriptionForItem(item) {
+  return item.hint?.specHint?.description || item.event.description || "";
 }
 
 function renderHints(container, hints) {

--- a/src/main/resources/static/raw-events.html
+++ b/src/main/resources/static/raw-events.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Raw Events</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="alternate icon" href="/favicon.ico">
+  <link rel="apple-touch-icon" href="/favicon.png">
+  <link rel="stylesheet" href="/log-catalog.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div>
+        <h1>Raw Events</h1>
+        <p id="summary">LOG_EVENT 원본 데이터를 조회하고 CSV로 다운로드합니다.</p>
+      </div>
+      <a class="button-link" href="/log-catalog">Log Catalog</a>
+    </header>
+
+    <section class="toolbar raw-toolbar" aria-label="raw event filters">
+      <label>
+        App
+        <input id="appNameInput" type="text" placeholder="order-service">
+      </label>
+      <label>
+        Worker
+        <input id="workerIdInput" type="text" placeholder="All workers">
+      </label>
+      <label>
+        EventName
+        <input id="eventNameInput" type="text" placeholder="orderCancelled">
+      </label>
+      <label>
+        From
+        <input id="fromInput" type="datetime-local">
+      </label>
+      <label>
+        To
+        <input id="toInput" type="datetime-local">
+      </label>
+      <label>
+        Limit
+        <select id="limitSelect">
+          <option value="100">100</option>
+          <option value="200">200</option>
+          <option value="500">500</option>
+        </select>
+      </label>
+      <div class="toolbar-actions">
+        <button id="loadButton" type="button">Load</button>
+        <button id="downloadButton" type="button">Download CSV</button>
+      </div>
+    </section>
+
+    <p id="message" class="message" role="status"></p>
+
+    <section class="raw-table-wrap" aria-label="raw events">
+      <table class="raw-table">
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>App</th>
+            <th>Worker</th>
+            <th>EventName</th>
+            <th>Payload</th>
+          </tr>
+        </thead>
+        <tbody id="rows"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <script src="/raw-events.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/raw-events.js
+++ b/src/main/resources/static/raw-events.js
@@ -1,0 +1,111 @@
+const els = {
+  appNameInput: document.querySelector("#appNameInput"),
+  workerIdInput: document.querySelector("#workerIdInput"),
+  eventNameInput: document.querySelector("#eventNameInput"),
+  fromInput: document.querySelector("#fromInput"),
+  toInput: document.querySelector("#toInput"),
+  limitSelect: document.querySelector("#limitSelect"),
+  loadButton: document.querySelector("#loadButton"),
+  downloadButton: document.querySelector("#downloadButton"),
+  message: document.querySelector("#message"),
+  rows: document.querySelector("#rows")
+};
+
+function setMessage(text) {
+  els.message.textContent = text || "";
+}
+
+function initializeFilters() {
+  const params = new URLSearchParams(window.location.search);
+  els.appNameInput.value = params.get("appName") || "";
+  els.workerIdInput.value = params.get("workerId") || "";
+  els.eventNameInput.value = params.get("eventName") || "";
+  els.limitSelect.value = params.get("limit") || "100";
+
+  const now = new Date();
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 999);
+
+  els.fromInput.value = toLocalDateTimeInput(params.get("from") ? new Date(params.get("from")) : start);
+  els.toInput.value = toLocalDateTimeInput(params.get("to") ? new Date(params.get("to")) : end);
+}
+
+function toLocalDateTimeInput(date) {
+  const pad = (value) => String(value).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate())
+  ].join("-") + "T" + [
+    pad(date.getHours()),
+    pad(date.getMinutes())
+  ].join(":");
+}
+
+function buildParams({ includeLimit }) {
+  const params = new URLSearchParams();
+  const appName = els.appNameInput.value.trim();
+  const workerId = els.workerIdInput.value.trim();
+  const eventName = els.eventNameInput.value.trim();
+  if (appName) params.set("appName", appName);
+  if (workerId) params.set("workerId", workerId);
+  if (eventName) params.set("eventName", eventName);
+  params.set("from", new Date(els.fromInput.value).toISOString());
+  params.set("to", new Date(els.toInput.value).toISOString());
+  if (includeLimit) params.set("limit", els.limitSelect.value);
+  return params;
+}
+
+async function loadRows() {
+  try {
+    setMessage("Loading raw LOG_EVENT data...");
+    const params = buildParams({ includeLimit: true });
+    const response = await fetch(`/api/events/custom?${params}`);
+    if (!response.ok) {
+      throw new Error(await response.text() || response.statusText);
+    }
+    const rows = await response.json();
+    renderRows(rows);
+    setMessage(`${rows.length} rows loaded. CSV downloads the full selected date range.`);
+  } catch (error) {
+    setMessage(error.message);
+  }
+}
+
+function renderRows(rows) {
+  if (rows.length === 0) {
+    els.rows.innerHTML = `<tr><td colspan="5" class="empty-cell">No LOG_EVENT data.</td></tr>`;
+    return;
+  }
+
+  els.rows.innerHTML = rows.map((row) => `
+    <tr>
+      <td>${escapeHtml(row.timestamp)}</td>
+      <td>${escapeHtml(row.appName)}</td>
+      <td>${escapeHtml(row.workerId)}</td>
+      <td>${escapeHtml(row.eventName)}</td>
+      <td><pre>${escapeHtml(JSON.stringify(row.payload, null, 2))}</pre></td>
+    </tr>
+  `).join("");
+}
+
+function downloadCsv() {
+  const params = buildParams({ includeLimit: false });
+  window.location.href = `/api/events/custom.csv?${params}`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+initializeFilters();
+els.loadButton.addEventListener("click", loadRows);
+els.downloadButton.addEventListener("click", downloadCsv);
+loadRows();


### PR DESCRIPTION
## Summary
- add a dedicated /raw-events page for LOG_EVENT raw data lookup
- extend custom event query API with appName, eventName, date range, and limit filters
- add CSV export for the selected filter/date range and link it from Log Catalog

## Test
- ./gradlew build